### PR TITLE
add `yarn migrate` instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If you are running the command for the first time, you should wait until the dat
 
 To start with a new database with no data, stop the command, remove the `.tmp` folder and run the command again.
 
+### Run migrations
+
+Set up the database schema by running:
+
+     $ yarn migrate
+
 ### Populate Data
 For the frontend and the API to work, you must have the data loaded on the local database.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "concurrently \"yarn api\" \"yarn frontend\"",
+    "migrate": "lerna run migrate --scope --scoreboard-api",
     "clocks": "lerna run clocks --scope --scoreboard-api",
     "seed": "lerna run seed --scope --scoreboard-api",
     "api": "lerna run start-dev --scope scoreboard-api",


### PR DESCRIPTION
A small change to add migration instructions to the readme.