### PR TITLE
use alternate port for postgres to avoid collisions with existing installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ API_URL=http://localhost:5000
 OSM_CONSUMER_KEY=your-oauth-key
 OSM_CONSUMER_SECRET=your-oauth-secre
 SESSION_SECRET=super-secret-sessions
-DATABASE_URL=postgres://postgres@localhost/scoreboard
+DATABASE_URL=postgres://postgres@localhost:5433/scoreboard
 ```
 
 | name | description
@@ -70,7 +70,7 @@ We use [lerna](https://github.com/lerna/lerna) for installation and package mana
 
      $ docker-compose run --rm --service-port db
 
-This command will create and run the database. The database files are stored under `.tmp` folder.
+This command will create and run the database on port `5433`. The database files are stored under `.tmp` folder.
 
 If you are running the command for the first time, you should wait until the database created.
 

--- a/api/.env.sample
+++ b/api/.env.sample
@@ -8,4 +8,4 @@ NODE_ENV=development
 OSM_CONSUMER_KEY=your-oauth-key
 OSM_CONSUMER_SECRET=your-oauth-secre
 SESSION_SECRET=super-secret-sessions
-DATABASE_URL=postgres://scoreboard:test@localhost/scoreboard
+DATABASE_URL=postgres://scoreboard:test@localhost:5433/scoreboard

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
       POSTGRES_USER: scoreboard 
       POSTGRES_DB: scoreboard 
     ports:
-      - 5432:5432 
+      - 5433:5432 
     volumes:
       - './.tmp/pg:/var/lib/postgresql/data'


### PR DESCRIPTION
We may not need this but wanted to open a PR just in case. This will help in the case that a user has postgres already running on the default port on their machine. I made the port `5433` but it could be something else.