### PR TITLE
Use <uid> as source-layer

### DIFF
--- a/frontend/src/components/UserStats.js
+++ b/frontend/src/components/UserStats.js
@@ -26,7 +26,7 @@ const editBox = (records) => (
       <h4 className="header--small header--with-description-lg">Extent of Edits</h4>
       <div style={{ position: "relative", height: "350px" }}>
         {(records && records.extent_uri)
-        ? <UserExtentMap extent={records.extent_uri} />
+        ? <UserExtentMap extent={records.extent_uri} uid={records.uid} />
         : <div>Extent map unavailable</div>
         }
       </div>

--- a/frontend/src/components/charts/UserExtentMap.js
+++ b/frontend/src/components/charts/UserExtentMap.js
@@ -5,6 +5,8 @@ mapboxgl.accessToken = 'pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0td
 
 class UserExtentMap extends Component {
   componentDidMount() {
+    const { uid } = this.props;
+
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: 'mapbox://styles/devseed/cj9iy816wb9x02smisy4y7id3',
@@ -33,7 +35,7 @@ class UserExtentMap extends Component {
         "id": "footprint-heat",
         "type": "heatmap",
         "source": "footprint",
-        "source-layer": "user_footprint",
+        "source-layer": uid,
         "maxzoom": 14,
         "paint": {
           //Increase the heatmap weight based on frequency and property magnitude

--- a/frontend/src/containers/Dashboard.js
+++ b/frontend/src/containers/Dashboard.js
@@ -81,7 +81,7 @@ class Dashboard extends Component {
             </div>
           </div>
           <div className="wrapper--map"></div>
-          <UserExtentMap extent={this.state.records.extent_uri} />
+          <UserExtentMap extent={this.state.records.extent_uri} uid={user['@']['id']} />
         </header>
         <section>
           <div className="row">


### PR DESCRIPTION
An upcoming change to user footprint generation in OSMesa changes MVT layer names to match their corresponding key (user id or hashtag, depending on context). This is being done to facilitate merging multiple users' footprints together into a single MVT (and to limit the number of tiles needing to be managed).

This should be deployed in conjunction with a configuration change to https://github.com/azavea/osmesa-stat-server (facilitated by @moradology) that will point footprints at their latest revision.