### PR TITLE
Fix bug when projects is empty

### DIFF
--- a/frontend/src/containers/Dashboard.js
+++ b/frontend/src/containers/Dashboard.js
@@ -80,9 +80,9 @@ class Dashboard extends Component {
 
   renderProjects() {
     const { projects } = this.props
-    const features = projects.records.features
 
     if (!projects) return (<div />)
+    const features = projects.records.features
 
     return (
       <section>


### PR DESCRIPTION
This is a bug I noticed when reviewing #59 that happened on the dashboard. If there are no projects in the database then it will error. 