### PR TITLE
Fix/campaign cards

### DIFF
--- a/api/src/routes/campaigns.js
+++ b/api/src/routes/campaigns.js
@@ -19,11 +19,11 @@ module.exports = async (req, res) => {
   try {
     const db = connection()
     let query = db('campaigns').whereNotNull('campaign_hashtag')
-    const [{ allCount }] = await query.clone().count('id as all_count')
+    const [{ allCount }] = await query.clone().count('id as allCount')
 
     if (search.length > 0) {
-      query = query.where('description', 'like', `%${search}%`)
-        .orWhere('name', 'like', `%${search}%`)
+      query = query.where('description', 'ilike', `%${search}%`)
+        .orWhere('name', 'ilike', `%${search}%`)
     }
     if (complMin > 0 || complMax < 100) {
       query = query.whereRaw(`(done / 2) + validated between ${complMin} and ${complMax}`)

--- a/components/CampaignCard.js
+++ b/components/CampaignCard.js
@@ -1,7 +1,11 @@
 import React from 'react'
 import Link from 'next/link'
 import trimLength from '../lib/utils/trim_length'
-import CampaignMap from './charts/CampaignMap'
+import dynamic from 'next/dynamic'
+
+const CampaignMap = dynamic(() => import('./charts/CampaignMap'), {
+  ssr: false
+})
 
 export default ({ campaign }) => {
   const {

--- a/lib/store/actions/campaigns.js
+++ b/lib/store/actions/campaigns.js
@@ -1,3 +1,39 @@
-export default store => ({
+import api, { createApiUrl } from '../../utils/api'
 
+function updateCampaigns (store, storeData) {
+  store.setState({ campaigns: { ...storeData, apiStatus: 'LOADING' } })
+  let { searchText: q, page, compl_min, compl_max } = storeData
+  console.log(storeData)
+  api('get', createApiUrl('/api/campaigns', { q, page, compl_min, compl_max }))
+    .then(res => {
+      store.setState({ campaigns: { ...storeData, apiStatus: 'SUCCESS', records: res.data } })
+    })
+    .catch(err => {
+      console.log(err)
+      store.setState({ campaigns: { ...storeData, apiStatus: 'ERROR' } })
+    })
+}
+
+export default store => ({
+  handleCampaignsSearch (state, value) {
+    const { campaigns } = state
+    campaigns.page = 1
+    campaigns.searchText = value
+    updateCampaigns(store, campaigns)
+  },
+
+  handleCampaignsPageChange (state, page) {
+    const { campaigns } = state
+    campaigns.page = page
+    updateCampaigns(store, campaigns)
+  },
+
+  handleCampaignsFilterChange (state, completeness) {
+    const { campaigns } = state
+    const { min: compl_min, max: compl_max } = completeness
+    campaigns.page = 1
+    campaigns.compl_min = compl_min
+    campaigns.compl_max = compl_max
+    updateCampaigns(store, campaigns)
+  }
 })

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -31,7 +31,7 @@ const exampleInitialState = {
     compl_max: 100,
     page: 1,
     apiStatus: 'LOADING',
-    records: {} 
+    records: {}
   },
   error: null
 }

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,5 +1,6 @@
 import createStore from 'unistore'
 import usersActions from './actions/users'
+import campaignsActions from './actions/campaigns'
 import api from '../utils/api'
 
 const exampleInitialState = {
@@ -23,6 +24,14 @@ const exampleInitialState = {
     page: 1,
     selectedActive: false,
     stats: null
+  },
+  campaigns: {
+    searchText: '',
+    compl_min: 0,
+    compl_max: 100,
+    page: 1,
+    apiStatus: 'LOADING',
+    records: {} 
   },
   error: null
 }
@@ -217,6 +226,7 @@ const userActions = store => ({
 export function actions (store) {
   return {
     ...userActions(store),
-    ...usersActions(store)
+    ...usersActions(store),
+    ...campaignsActions(store)
   }
 }

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -42,7 +42,7 @@ export class Campaigns extends Component {
   render () {
     const { page, searchText, compl_min, compl_max } = this.props.campaigns
     const { records: { total, records, all_count }, apiStatus } = this.props.campaigns
-    
+
     return (
       <div className='Campaigns'>
         <header className='header--internal--green header--page'>

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -7,9 +7,7 @@ import CampaignsListing from '../components/CampaignsListing'
 
 import { actions } from '../lib/store'
 import { connect } from 'unistore/react'
-
-
-class Campaigns extends Component {
+export class Campaigns extends Component {
   constructor () {
     super()
 

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -1,87 +1,50 @@
 import React, { Component } from 'react'
 import '../styles/Campaigns.scss'
-import api, { createApiUrl } from '../lib/utils/api'
 import queryString from 'query-string'
 import Pagination from 'react-js-pagination'
 import CampaignFilters from '../components/CampaignFilters'
 import CampaignsListing from '../components/CampaignsListing'
 
-const initialState = {
-  searchText: '',
-  compl_min: 0,
-  compl_max: 100,
-  page: 1
-}
+import { actions } from '../lib/store'
+import { connect } from 'unistore/react'
 
-const campaignsReducer = (state = initialState, action) => {
-  switch (action.type) {
-    case 'PAGE_CHANGE':
-      return Object.assign(state, { page: action.page })
-    case 'SEARCH_TEXT_CHANGE':
-      return Object.assign(state, { searchText: action.searchText, page: 1 })
-    case 'COMPLETENESS_FILTER_CHANGE': {
-      const { min: compl_min, max: compl_max } = action.completeness
-      return Object.assign(state, { compl_min, compl_max, page: 1 })
-    }
-    default:
-      return state
-  }
-}
 
 class Campaigns extends Component {
   constructor () {
     super()
-    this.state = {
-      records: {},
-      apiStatus: 'LOADING',
-      ...initialState
-    }
+
     this.handlePageChange = this.handlePageChange.bind(this)
     this.handleFilterChange = this.handleFilterChange.bind(this)
     this.handleSearch = this.handleSearch.bind(this)
-    this.dispatch = this.dispatch.bind(this)
-  }
-
-  dispatch (action) {
-    const state = this.state
-    const newState = campaignsReducer(state, action)
-
-    this.setState(Object.assign(newState, { apiStatus: 'LOADING' }))
-    let { searchText: q, page, compl_min, compl_max } = newState
-
-    api('get', createApiUrl('/api/campaigns', { q, page, compl_min, compl_max }))
-      .then(res => {
-        this.setState(Object.assign({ records: res.data, apiStatus: 'SUCCESS' }))
-      })
-      .catch(err => {
-        console.log(err)
-        this.setState({ apiStatus: 'ERROR' })
-      })
   }
 
   handleSearch (event) {
-    this.dispatch({ type: 'SEARCH_TEXT_CHANGE', searchText: event.target.value })
+    this.props.handleCampaignsSearch(event.target.value)
   }
 
   handleFilterChange (completeness) {
-    this.dispatch({ type: 'COMPLETENESS_FILTER_CHANGE', completeness })
+    this.props.handleCampaignsFilterChange(completeness)
   }
 
   handlePageChange (pageNumber) {
     this.setState({ records: {} })
     window.scrollTo(0, 0)
-    this.dispatch({ type: 'PAGE_CHANGE', page: pageNumber || 1 })
+    this.props.handleCampaignsPageChange(pageNumber || 1)
   }
 
   componentDidMount () {
     if (this.props.location) {
       let { page } = queryString.parse(this.props.location.search)
-      this.dispatch({ type: 'PAGE_CHANGE', page: page || 1 })
+      this.props.handleCampaignsPageChange(page || 1)
+    } else {
+      this.props.handleCampaignsPageChange(1)
     }
   }
 
   render () {
-    const { page, records: { total, records, all_count }, searchText, compl_min, compl_max, apiStatus } = this.state
+    const { page, searchText, compl_min, compl_max } = this.props.campaigns
+    const { records: { total, records, all_count }, apiStatus } = this.props.campaigns
+    
     return (
       <div className='Campaigns'>
         <header className='header--internal--green header--page'>
@@ -123,4 +86,4 @@ class Campaigns extends Component {
   }
 };
 
-export default Campaigns
+export default connect(['campaigns'], actions)(Campaigns)

--- a/tests/containers.test.js
+++ b/tests/containers.test.js
@@ -4,7 +4,7 @@ import { Provider } from 'unistore/react'
 
 // import {Campaigns, Campaign, Home, User, Users, About} from '../containers';
 import { Home } from '../pages/index'
-import Campaigns from '../pages/campaigns'
+import { Campaigns } from '../pages/campaigns'
 import Campaign from '../pages/campaign'
 import User from '../pages/user'
 import { Users } from '../pages/users'
@@ -18,7 +18,19 @@ function mockAction () {
 
 it('Campaigns renders without crashing', () => {
   const div = document.createElement('div')
-  const mockProps = {}
+  const mockProps = {
+    campaigns: {
+      searchText: '',
+      compl_min: 0,
+      compl_max: 100,
+      page: 1,
+      apiStatus: 'LOADING',
+      records: {}
+    },
+    handleCampaignsSearch: mockAction,
+    handleCampaignsFilterChange: mockAction,
+    handleCampaignsPageChange: mockAction
+  }
 
   const page = (
     <Provider store={store}>


### PR DESCRIPTION
This does:
* fix a bug for the campaign cards to render maps client side instead of server side
* connects the campaigns to the store, and simplifies logic for requesting data from the API. We should maybe use the same logic for the users page @sethvincent

@alyssadelaine there is a weird bug in how many results are pulled from the DB on initial page load. I didn't fix it because you're going to rip that out so that data isn't pulled from the DB