### PR TITLE
Fix babel preset for production, closes #76

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   },
   "babel": {
     "env": {
+      "production": {
+        "presets": [
+          "next/babel"
+        ]
+      },
       "development": {
         "presets": [
           "next/babel"


### PR DESCRIPTION
This resolves the `next build` error because NODE_ENV is set to production when building from the command line. 