### PR TITLE
serve swagger docs from /api and /api/docs

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -61,6 +61,6 @@ app.use(passport.session())
 app.use('/auth', authRouter)
 app.use('/api', router)
 app.use('/scoreboard/api', router)
-app.use(['/api/docs'], swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+app.use(['/api', '/api/docs'], swaggerUi.serve, swaggerUi.setup(swaggerDocument))
 
 module.exports = app


### PR DESCRIPTION
closes #103 

This makes it so swagger docs are served from both `/api` and `/api/docs`.