### PR TITLE
fix development knex config

### DIFF
--- a/api/src/db/knexfile.js
+++ b/api/src/db/knexfile.js
@@ -37,6 +37,5 @@ module.exports = {
     },
     debug: process.env.KNEX_DEBUG || false
   }),
-  staging: def,
   production: def
 }

--- a/api/src/db/knexfile.js
+++ b/api/src/db/knexfile.js
@@ -31,12 +31,12 @@ const def = {
 
 module.exports = {
   test: test,
-  development: Object.assign({}, {
+  development: Object.assign(def, {
     seeds: {
       directory: path.join(__dirname, 'seeds', 'development')
     },
     debug: process.env.KNEX_DEBUG || false
-  }, def),
+  }),
   staging: def,
   production: def
 }


### PR DESCRIPTION
`def` was overriding the `development` config so `production` seeds were being run in development.