### PR TITLE
Re-enable footprint-point layer

### DIFF
--- a/components/charts/UserExtentMap.js
+++ b/components/charts/UserExtentMap.js
@@ -93,7 +93,7 @@ class UserExtentMap extends Component {
         'id': 'footprint-point',
         'type': 'circle',
         'source': 'footprint',
-        'source-layer': 'user_footprint',
+        'source-layer': uid.toString(),
         'minzoom': 7,
         'paint': {
           // Size circle raidus by earthquake magnitude and zoom level


### PR DESCRIPTION
When I updated this before, I missed that there were 2 layers in use. This fixes the circle layer so that it renders data from the correct source layer.