### PR TITLE
Feature/194 task priorities

### DIFF
--- a/api/src/db/migrations/20181217173435_team_assignment_priority.js
+++ b/api/src/db/migrations/20181217173435_team_assignment_priority.js
@@ -1,0 +1,20 @@
+
+exports.up = async function (knex) {
+  try {
+    await knex.schema.alterTable('team_assignments', t => {
+      t.integer('team_priority')
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+exports.down = async function (knex) {
+  try {
+    await knex.schema.alterTable('team_assignments', t => {
+      t.dropColumn('team_priority')
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/api/src/routes/user.js
+++ b/api/src/routes/user.js
@@ -100,7 +100,7 @@ async function get (req, res) {
     if (teams && teams.length > 0) {
       assignments = await db('team_assignments').whereIn('team_id', teams.map(t => t.id))
         .join('campaigns', 'campaigns.id', '=', 'team_assignments.campaign_id')
-        .select('campaign_id', 'team_id', 'campaigns.name', 'campaigns.campaign_hashtag', 'campaigns.priority')
+        .select('campaign_id', 'team_id', 'team_priority', 'campaigns.name', 'campaigns.campaign_hashtag', 'campaigns.priority')
 
       // Map names
       assignments = assignments.map(assignment => {

--- a/components/AdminCampaignsSearch.js
+++ b/components/AdminCampaignsSearch.js
@@ -40,11 +40,10 @@ class Assignment extends Component {
     return (
       <tr key={`campaign-${record.name}`} className='admin-table-row'>
         <td>{`${record.name} - project-${(record.tm_id || record.id)}`}</td>
-        <td>{ selector }</td>
+        <td><div style={{ 'padding': '5px' }}>{ selector }</div></td>
         <td><button style={{ 'padding': '5px' }} className='button' onClick={() => this.handleRemove(record)} >Remove</button></td>
       </tr>
     )
-
   }
 }
 

--- a/components/AdminCampaignsSearch.js
+++ b/components/AdminCampaignsSearch.js
@@ -2,6 +2,51 @@ import Pagination from 'react-js-pagination'
 import React, { Component } from 'react'
 import { connect } from 'unistore/react'
 import { actions } from '../lib/store'
+import Select from 'react-select'
+
+class Assignment extends Component {
+  constructor (props) {
+    super(props)
+
+    this.handleChange = this.handleChange.bind(this)
+    this.handleRemove = this.handleRemove.bind(this)
+  }
+
+  handleChange (selectedOption) {
+    let record = Object.assign({}, this.props.record, { team_priority: selectedOption })
+    this.props.handleChange(record)
+  }
+
+  handleRemove () {
+    this.props.handleRemove(this.props.record)
+  }
+
+  render () {
+    const record = this.props.record
+    const { team_priority } = record
+
+    // Select
+    let selector = <Select
+      simpleValue
+      value={team_priority}
+      onChange={this.handleChange}
+      options={[
+        { value: 1, label: '1' },
+        { value: 2, label: '2' },
+        { value: 3, label: '3' }
+      ]}
+    />
+
+    return (
+      <tr key={`campaign-${record.name}`} className='admin-table-row'>
+        <td>{`${record.name} - project-${(record.tm_id || record.id)}`}</td>
+        <td>{ selector }</td>
+        <td><button style={{ 'padding': '5px' }} className='button' onClick={() => this.handleRemove(record)} >Remove</button></td>
+      </tr>
+    )
+
+  }
+}
 
 class CampaignSearch extends Component {
   constructor (props) {
@@ -11,6 +56,7 @@ class CampaignSearch extends Component {
     this.handlePageChange = this.handlePageChange.bind(this)
     this.onSearchCampaignClick = this.onSearchCampaignClick.bind(this)
     this.onSelectedCampaignClick = this.onSelectedCampaignClick.bind(this)
+    this.onTaskPriorityChange = this.onTaskPriorityChange.bind(this)
   }
 
   handleSearch (event) {
@@ -29,6 +75,10 @@ class CampaignSearch extends Component {
     this.props.handleCampaignsPageChange(pageNumber || 1)
   }
 
+  onTaskPriorityChange (campaign) {
+    this.props.addCampaign(campaign)
+  }
+
   componentDidMount () {
     this.props.handleCampaignsPageChange(1)
   }
@@ -41,6 +91,13 @@ class CampaignSearch extends Component {
     const { records: { total, records } } = this.props.campaigns
     if (!records) return <div />
 
+    let assignments = selectedCampaigns.map(record =>
+      <Assignment record={record}
+        handleChange={this.onTaskPriorityChange}
+        handleRemove={this.onSelectedCampaignClick}
+      />
+    )
+
     return (
       <div>
         {
@@ -51,16 +108,11 @@ class CampaignSearch extends Component {
                 <thead>
                   <tr>
                     <th>Name</th>
-                    <th>Priority</th>
+                    <th>Team Priority</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {selectedCampaigns.map(record => (
-                    <tr key={`campaign-${record.name}`} onClick={() => this.onSelectedCampaignClick(record)} className='admin-table-row'>
-                      <td>{`${record.name} - project-${(record.tm_id || record.id)}`}</td>
-                      <td>{record.priority}</td>
-                    </tr>
-                  ))}
+                  {assignments}
                 </tbody>
               </table>
             </section>)
@@ -81,7 +133,7 @@ class CampaignSearch extends Component {
               <thead>
                 <tr>
                   <th>Name</th>
-                  <th>Priority</th>
+                  <th>Task Priority</th>
                 </tr>
               </thead>
               <tbody>

--- a/components/AssignmentsTable.js
+++ b/components/AssignmentsTable.js
@@ -14,7 +14,6 @@ export default ({ assignments }) => {
       <tbody>
         {
           assignments
-            .reverse()
             .map((assignment, idx) => {
               return (
                 <tr key={`assignment-${assignment.id}`}>

--- a/components/CampaignCard.js
+++ b/components/CampaignCard.js
@@ -15,7 +15,8 @@ export default ({ campaign }) => {
     geometry,
     done,
     validated,
-    campaign_hashtag
+    campaign_hashtag,
+    team_priority
   } = campaign
   return (
     <Link href={`/campaigns/${campaign_hashtag}`}>
@@ -24,7 +25,7 @@ export default ({ campaign }) => {
           <div className='map-campaign-sm'><CampaignMap feature={JSON.parse(geometry)} interactive={false} /></div>
           <div className='card-content'>
             <h4 className='header--small header--with-description'>{trimLength(name, 70)}</h4>
-            <span className='description--project'>Project #{tm_id}</span>
+            <span className='description--project'>Project #{tm_id} { team_priority ? `- Priority ${parseInt(team_priority, 10)}` : ''}</span>
             <p>{trimLength(description, 190)}</p>
             <ul className='card-stats'>
               <li className='list--inline'>

--- a/pages/admin/teams-edit.js
+++ b/pages/admin/teams-edit.js
@@ -31,6 +31,7 @@ export class AdminTeamsEdit extends Component {
     this.handleHashtagInputChange = this.handleHashtagInputChange.bind(this)
     this.resetInputs = this.resetInputs.bind(this)
     this.renderCampaignsSelectSection = this.renderCampaignsSelectSection.bind(this)
+
     this.addCampaignToTeam = this.addCampaignToTeam.bind(this)
     this.removeCampaignFromTeam = this.removeCampaignFromTeam.bind(this)
 
@@ -357,7 +358,7 @@ export class AdminTeamsEdit extends Component {
       bio: descriptionInput,
       name: nameInput,
       hashtag: hashtagInput,
-      campaigns: teamCampaigns.map(c => c.id),
+      campaigns: teamCampaigns.map(c => ({ 'id': c.id, 'team_priority': c.team_priority })),
       newusers: teamUsers.map(u => u.osm_id),
       oldusers: initialUsers.map(u => u.osm_id)
     }

--- a/pages/dashboard-component.js
+++ b/pages/dashboard-component.js
@@ -12,6 +12,7 @@ import DataNotAvailable from '../components/DataNotAvailable'
 import InlineList from '../components/InlineList'
 import FilterBar from '../components/FilterBar'
 import AssignmentsTable from '../components/AssignmentsTable'
+import { sortBy, prop } from 'ramda'
 
 const UserExtentMap = dynamic(() => import('../components/charts/UserExtentMap'), {
   ssr: false
@@ -198,9 +199,9 @@ class Dashboard extends Component {
       { name: 'All', id: 'all' }
     ]
 
-    let teamAssignments = assignments.map(task => {
+    let teamAssignments = sortBy(prop('team_priority'), assignments).map(task => {
       return {
-        priority: task.priority,
+        priority: task.team_priority ? `team priority: ${task.team_priority}` : task.priority,
         name: task.name,
         assigned_by: task.team_name,
         campaign_hashtag: task.campaign_hashtag
@@ -208,7 +209,7 @@ class Dashboard extends Component {
     })
 
     const allCampaigns = {
-      favorites,
+      favorites: sortBy(prop('priority'), favorites),
       teams: teamAssignments,
       all: teamAssignments.concat(favorites)
     }

--- a/pages/team.js
+++ b/pages/team.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'unistore/react'
 import { actions } from '../lib/store'
 import CampaignCard from '../components/CampaignCard'
+import { sortBy, prop } from 'ramda'
 
 export class Team extends Component {
   componentDidMount () {
@@ -65,7 +66,7 @@ export class Team extends Component {
         <section className='section--tertiary'>
           <div className='row'>
             <h2>Assigned Campaigns</h2>
-            {team.campaigns.map(record => <CampaignCard key={record.id} campaign={record} />)}
+            {sortBy(prop('team_priority'), team.campaigns).map(record => <CampaignCard key={record.id} campaign={record} />)}
           </div>
         </section>
       </div>


### PR DESCRIPTION
Closes #194 

Adds a team_priority column in team_assignments
Allows admins to select teams
Shows the team priority on the individual team page and in the assignments table

![image](https://user-images.githubusercontent.com/719357/50125184-b84bac00-0235-11e9-85a7-4ed85597fb00.png)

![](https://kamicut-monosnap.s3.amazonaws.com/Mozilla_Firefox_2018-12-17_19-56-02.png)

![](https://kamicut-monosnap.s3.amazonaws.com/Mozilla_Firefox_2018-12-17_19-54-50.png)