### PR TITLE
add admin section list to dashboard if user is admin

### DIFF
--- a/components/AdminSectionList.js
+++ b/components/AdminSectionList.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import Link from './Link'
+
+export default () => {
+  return (
+    <ul className='list-grid'>
+      <li>
+        <h3 className='header--medium'>
+          Badges
+        </h3>
+        <ul>
+          <li>
+            <Link href='/admin/badges'>
+              <a className='link--normal'>Badge list</a>
+            </Link>
+          </li>
+          <li>
+            <Link href='/admin/badges/add'>
+              <a className='link--normal'>Create new badge</a>
+            </Link>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <h3 className='header--medium'>
+          Teams
+        </h3>
+        <ul>
+          <li>
+            <Link href='/admin/teams'>
+              <a className='link--normal'>Team list</a>
+            </Link>
+          </li>
+          <li>
+            <Link href='/admin/teams/add'>
+              <a className='link--normal'>Create new team</a>
+            </Link>
+          </li>
+        </ul>
+      </li>
+      <li>
+        <h3 className='header--medium'>
+          Users
+        </h3>
+        <ul>
+          <li>
+            <Link href='/admin/users'>
+              <a className='link--normal'>User list</a>
+            </Link>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  )
+}

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -7,6 +7,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/AdminHeader'
+import AdminSectionList from '../../components/AdminSectionList'
 
 export class Admin extends Component {
   constructor () {
@@ -54,40 +55,9 @@ export class Admin extends Component {
           </div>
         </header>
         <section>
-          <div className='row'>
-            <div className='content'>
-              <ul className='list-grid'>
-                <li>
-                  <Link href='/admin/users'>
-                    <a>
-                      <div>
-                        <h2 className='header--large'>Users</h2>
-                        <p>Manage user roles</p>
-                      </div>
-                    </a>
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/admin/badges'>
-                    <a>
-                      <div>
-                        <h2 className='header--large'>Badges</h2>
-                        <p>Manage badges</p>
-                      </div>
-                    </a>
-                  </Link>
-                </li>
-                <li>
-                  <Link href='/admin/teams'>
-                    <a>
-                      <div>
-                        <h2 className='header--large'>Teams</h2>
-                        <p>Manage teams</p>
-                      </div>
-                    </a>
-                  </Link>
-                </li>
-              </ul>
+          <div class="row">
+            <div class="content">
+              <AdminSectionList />
             </div>
           </div>
         </section>

--- a/pages/dashboard-component.js
+++ b/pages/dashboard-component.js
@@ -3,8 +3,9 @@ import dynamic from 'next/dynamic'
 import Link from '../components/Link'
 import { connect } from 'unistore/react'
 import { withAlert } from 'react-alert'
-import { actions } from '../lib/store'
 
+import { actions } from '../lib/store'
+import { isAdmin } from '../lib/utils/roles'
 import countryList from '../lib/utils/country-list'
 import BadgeInProgress from '../components/BadgeInProgress'
 import NotLoggedIn from '../components/NotLoggedIn'
@@ -12,6 +13,7 @@ import DataNotAvailable from '../components/DataNotAvailable'
 import InlineList from '../components/InlineList'
 import FilterBar from '../components/FilterBar'
 import AssignmentsTable from '../components/AssignmentsTable'
+import AdminSectionList from '../components/AdminSectionList'
 import { sortBy, prop } from 'ramda'
 
 const UserExtentMap = dynamic(() => import('../components/charts/UserExtentMap'), {
@@ -130,6 +132,7 @@ class Dashboard extends Component {
               }
             </div>
             <div className='content--with-sidebar'>
+              {isAdmin(authenticatedUser.account.roles) && this.renderAdmin()}
               {this.renderAssignments()}
               {this.renderBadges()}
             </div>
@@ -186,6 +189,19 @@ class Dashboard extends Component {
         <div className='wrapper--map' />
         <UserExtentMap extent={account.records.extent_uri} uid={osmUser['@']['id']} />
       </header>
+    )
+  }
+
+  renderAdmin () {
+    return (
+      <div  style={{ marginBottom: 50 }}>
+        <h2 className='header--large header--with-description'>
+          <Link href='/campaigns'>
+            <a class='header-link'>Admin</a>
+          </Link>
+        </h2>
+        <AdminSectionList />
+      </div>
     )
   }
 

--- a/styles/Admin.scss
+++ b/styles/Admin.scss
@@ -44,21 +44,25 @@
 }
 
 .list-grid {
-  li {
+  > li {
     display: inline-block;
     width: 20%;
-
-    a {
-      padding: 20px;
-      display: block;
-      margin-right: 4%; 
-      border-radius: 2px;
-    }
-
-    a:hover {
-      background-color: #fafafc;
-    }
+    vertical-align: top;
   }
+
+  h3 {
+    margin: 0;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+  }
+
+  p {
+    margin: 0;
+  }
+
 }
 
 .admin-sidebar-links {


### PR DESCRIPTION
Links to admin pages now appear in a component on the dashboard if the user is an admin. I've reused the same component on the admin index page.

this might be all we need for #201 but open to other improvements as well.

<img width="706" alt="screen shot 2018-12-20 at 10 44 18 am" src="https://user-images.githubusercontent.com/164214/50304262-5f9e2e00-0444-11e9-9f45-11b0caa325f6.png">
