### PR TITLE
Adds a proxy url setting for tasking managers

### DIFF
--- a/api/src/db/migrations/20190205135054_taskers_proxy.js
+++ b/api/src/db/migrations/20190205135054_taskers_proxy.js
@@ -1,0 +1,20 @@
+
+exports.up = async function (knex) {
+  try {
+    await knex.schema.alterTable('taskers', t => {
+      t.string('url_proxy')
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+exports.down = async function (knex) {
+  try {
+    await knex.schema.alterTable('taskers', t => {
+      t.dropColumn('url_proxy')
+    })
+  } catch (e) {
+    console.error(e)
+  }
+}

--- a/api/src/services/tm.js
+++ b/api/src/services/tm.js
@@ -1,7 +1,7 @@
 const { TM2API, TM3API, FakeTMAPI } = require('./tm_types')
 
 class TM {
-  constructor (id, type, url) {
+  constructor (id, type, url, api_url) {
     if (!type) {
       throw new Error('TM needs type')
     }
@@ -10,15 +10,19 @@ class TM {
       throw new Error('TM needs URL')
     }
 
+    this.id = id
     this.url = url.replace(/\/+$/, '') // Ensure no trailing slashes in URL
+    this.api_url = api_url || this.url
+    this.api_url = this.api_url.replace(/\/+$/, '')
+
     this.type = type
 
     switch (type) {
       case 'tm2': {
-        return new TM2API(url, id)
+        return new TM2API(this.url, this.id, this.api_url)
       }
       case 'tm3': {
-        return new TM3API(url, id)
+        return new TM3API(this.url, this.id, this.api_url)
       }
       case 'test': {
         return new FakeTMAPI()

--- a/api/src/services/tm_types/tm2.js
+++ b/api/src/services/tm_types/tm2.js
@@ -6,8 +6,9 @@ const { pick, merge } = require('ramda')
  * Methods to grab data from tasking manager version 2
  */
 class TM2API {
-  constructor (url, tasker_id) {
+  constructor (url, tasker_id, api_url) {
     this.url = url
+    this.api_url = api_url
     this.tasker_id = tasker_id
   }
 
@@ -26,7 +27,7 @@ class TM2API {
     let records = []
 
     while (keepGoing) {
-      let resp = JSON.parse(await rp(`${this.url}/projects.json?page=${page}`))
+      let resp = JSON.parse(await rp(`${this.api_url}/projects.json?page=${page}`))
       let features = resp.features
       for (let i = 0; i < features.length; i++) {
         let feature = features[i]
@@ -50,7 +51,7 @@ class TM2API {
   }
 
   getProject (id) {
-    return rp(`${this.url}/project/${id}.json`)
+    return rp(`${this.api_url}/project/${id}.json`)
   }
 
   getLastUpdated (id) {
@@ -62,7 +63,7 @@ class TM2API {
   }
 
   getTasks (id) {
-    return rp(`${this.url}/project/${id}/tasks.json`)
+    return rp(`${this.api_url}/project/${id}/tasks.json`)
   }
 
   toDBObjects (records) {

--- a/api/src/services/tm_types/tm3.js
+++ b/api/src/services/tm_types/tm3.js
@@ -7,8 +7,9 @@ const extractCampaignHashtag = require('../../utils/extractCampaignHashtag')
  * Methods to grab data from tasking manager version 3
  */
 class TM3API {
-  constructor (url, tasker_id) {
+  constructor (url, tasker_id, api_url) {
     this.url = url
+    this.api_url = api_url
     this.tasker_id = tasker_id
   }
 
@@ -31,7 +32,7 @@ class TM3API {
   async getProjects () {
     let records = []
     let firstResp = await rp({
-      uri: `${this.url}/api/v1/project/search`,
+      uri: `${this.api_url}/api/v1/project/search`,
       headers: { 'Accept-Language': 'en-US,en;q=0.9' }
     })
     let json = JSON.parse(firstResp)
@@ -42,7 +43,7 @@ class TM3API {
     let promises = []
     for (let i = 2; i < numPages; i++) {
       promises.push(limit(() => rp({
-        uri: `${this.url}/api/v1/project/search?page=${i}`,
+        uri: `${this.api_url}/api/v1/project/search?page=${i}`,
         headers: { 'Accept-Language': 'en-US,en;q=0.9' }
       })))
     }
@@ -62,20 +63,20 @@ class TM3API {
 
   getProject (id) {
     return rp({
-      uri: `${this.url}/api/v1/project/${id}?as_file=false`,
+      uri: `${this.api_url}/api/v1/project/${id}?as_file=false`,
       headers: { 'Accept-Language': 'en-US,en;q=0.9' }
     })
   }
 
   getProjectAoi (id) {
     return rp({
-      uri: `${this.url}/api/v1/project/${id}/aoi?as_file=false`
+      uri: `${this.api_url}/api/v1/project/${id}/aoi?as_file=false`
     })
   }
 
   getTasks (id) {
     return rp({
-      uri: `${this.url}/api/v1/project/${id}/tasks`
+      uri: `${this.api_url}/api/v1/project/${id}/tasks`
     })
   }
 

--- a/api/tests/services/tm2.test.js
+++ b/api/tests/services/tm2.test.js
@@ -44,3 +44,14 @@ test.serial('Test TM2 schema', async t => {
     t.true(has(key, project.properties))
   })
 })
+
+test.serial('Test URL forming', async t => {
+  const tm = new TM(1, 'tm2', 'http://tasks.openstreetmap.id', 'http://localhost:4849')
+  let projects = await tm.getProjects() // Should get from the proxy
+
+  const project = projects.find(p => p.id === 361)
+  t.truthy(project)
+
+  const url = tm.getUrlForProject(project.id)
+  t.is(url, `http://tasks.openstreetmap.id/project/361`)
+})

--- a/api/tests/services/tm3.test.js
+++ b/api/tests/services/tm3.test.js
@@ -57,3 +57,14 @@ test.serial('Test TM3 schema', async t => {
     t.true(has(key, project))
   })
 })
+
+test.serial('Test URL forming', async t => {
+  const tm = new TM(1, 'tm3', 'http://tasks.openstreetmap.us', 'http://localhost:4848')
+  let projects = await tm.getProjects() // Should get from the proxy
+
+  const project = projects.find(p => p.projectId === 77)
+  t.truthy(project)
+  
+  const url = tm.getUrlForProject(project.projectId)
+  t.is(url, `http://tasks.openstreetmap.us/project/77`)
+})

--- a/api/tests/services/tm3.test.js
+++ b/api/tests/services/tm3.test.js
@@ -64,7 +64,7 @@ test.serial('Test URL forming', async t => {
 
   const project = projects.find(p => p.projectId === 77)
   t.truthy(project)
-  
+
   const url = tm.getUrlForProject(project.projectId)
   t.is(url, `http://tasks.openstreetmap.us/project/77`)
 })

--- a/pages/admin/tasking-managers-add.js
+++ b/pages/admin/tasking-managers-add.js
@@ -19,7 +19,8 @@ export class AdminTaskersAdd extends Component {
       disableInteraction: false,
       nameInput: '',
       typeInput: null,
-      hashtagInput: ''
+      urlInput: '',
+      urlProxyInput: '',
     }
 
     // Event handlers
@@ -27,6 +28,7 @@ export class AdminTaskersAdd extends Component {
     this.handleDescriptionInputChange = this.handleDescriptionInputChange.bind(this)
     this.handleNameInputChange = this.handleNameInputChange.bind(this)
     this.handleUrlInputChange = this.handleUrlInputChange.bind(this)
+    this.handleUrlProxyInputChange = this.handleUrlProxyInputChange.bind(this)
     this.handleTypeChange = this.handleTypeChange.bind(this)
     this.resetInputs = this.resetInputs.bind(this)
   }
@@ -204,6 +206,23 @@ export class AdminTaskersAdd extends Component {
             value={this.state.descriptionInput}
           />
         </div>
+        <h2 className='header--medium'>Advanced Settings</h2>
+        <div className='form__input-unit'>
+          <label
+            className='form__label'
+            htmlFor='add-new-tasker-url-proxy'
+          >
+            Proxy URL (API behind firewall)
+          </label>
+          <input
+            id='tasker-url-proxy'
+            name='tasker-url-proxy'
+            onChange={this.handleUrlProxyInputChange}
+            placeholder='https://internal-ip/tasks'
+            type='text'
+            value={this.state.urlProxyInput}
+          />
+        </div>
       </div>
     )
   }
@@ -229,6 +248,13 @@ export class AdminTaskersAdd extends Component {
     })
   }
 
+  handleUrlProxyInputChange (e) {
+    const { value } = e.target
+    this.setState({
+      urlProxyInput: value
+    })
+  }
+
   handleTypeChange (typeInput) {
     this.setState({
       typeInput
@@ -242,6 +268,7 @@ export class AdminTaskersAdd extends Component {
       descriptionInput,
       nameInput,
       urlInput,
+      urlProxyInput,
       typeInput
     } = this.state
 
@@ -249,6 +276,7 @@ export class AdminTaskersAdd extends Component {
       description: descriptionInput,
       name: nameInput,
       url: urlInput,
+      url_proxy: urlProxyInput,
       type: typeInput.value
     }
 
@@ -259,6 +287,7 @@ export class AdminTaskersAdd extends Component {
     this.setState({
       descriptionInput: '',
       urlInput: '',
+      urlProxyInput: '',
       disableInteraction: false,
       nameInput: ''
     })

--- a/pages/admin/tasking-managers-add.js
+++ b/pages/admin/tasking-managers-add.js
@@ -20,7 +20,7 @@ export class AdminTaskersAdd extends Component {
       nameInput: '',
       typeInput: null,
       urlInput: '',
-      urlProxyInput: '',
+      urlProxyInput: ''
     }
 
     // Event handlers

--- a/pages/admin/tasking-managers-edit.js
+++ b/pages/admin/tasking-managers-edit.js
@@ -18,8 +18,9 @@ export class AdminTaskersEdit extends Component {
       descriptionInput: '',
       disableInteraction: false,
       nameInput: '',
-      typeInput: null,
-      hashtagInput: ''
+      urlInput: '',
+      urlProxyInput: '',
+      typeInput: null
     }
 
     // Event handlers
@@ -27,6 +28,7 @@ export class AdminTaskersEdit extends Component {
     this.handleDescriptionInputChange = this.handleDescriptionInputChange.bind(this)
     this.handleNameInputChange = this.handleNameInputChange.bind(this)
     this.handleUrlInputChange = this.handleUrlInputChange.bind(this)
+    this.handleUrlProxyInputChange = this.handleUrlProxyInputChange.bind(this)
     this.handleTypeChange = this.handleTypeChange.bind(this)
     this.resetInputs = this.resetInputs.bind(this)
   }
@@ -51,6 +53,7 @@ export class AdminTaskersEdit extends Component {
         nameInput: tasker.name,
         descriptionInput: tasker.description,
         urlInput: tasker.url,
+        urlProxyInput: tasker.url_proxy,
         typeInput: tasker.type
       })
     }
@@ -107,7 +110,7 @@ export class AdminTaskersEdit extends Component {
             </div>
             <div className='widget-75'>
               <div className='row'>
-                <h1 className='header--xlarge'>Add a new tasking manager</h1>
+                <h1 className='header--xlarge'>Edit tasking manager</h1>
               </div>
               <div className='row'>
                 {this.renderUpdateForm()}
@@ -189,6 +192,7 @@ export class AdminTaskersEdit extends Component {
         onSubmit={this.handleUpdateFormSubmit}
       >
         {this.renderBasicDetailsSection()}
+
         <div className='form__footer'>
           <button
             className='button'
@@ -274,6 +278,23 @@ export class AdminTaskersEdit extends Component {
             value={this.state.descriptionInput}
           />
         </div>
+        <h2 className='header--medium'>Advanced Settings</h2>
+        <div className='form__input-unit'>
+          <label
+            className='form__label'
+            htmlFor='add-new-tasker-url'
+          >
+            Proxy URL (API behind firewall)
+          </label>
+          <input
+            id='tasker-url-proxy'
+            name='tasker-url-proxy'
+            onChange={this.handleUrlProxyInputChange}
+            placeholder='https://internal-ip/tasks'
+            type='text'
+            value={this.state.urlProxyInput}
+          />
+        </div>
       </div>
     )
   }
@@ -299,6 +320,13 @@ export class AdminTaskersEdit extends Component {
     })
   }
 
+  handleUrlProxyInputChange (e) {
+    const { value } = e.target
+    this.setState({
+      urlProxyInput: value
+    })
+  }
+
   handleTypeChange (typeInput) {
     this.setState({
       typeInput
@@ -312,6 +340,7 @@ export class AdminTaskersEdit extends Component {
       descriptionInput,
       nameInput,
       urlInput,
+      urlProxyInput,
       typeInput
     } = this.state
 
@@ -319,6 +348,7 @@ export class AdminTaskersEdit extends Component {
       description: descriptionInput,
       name: nameInput,
       url: urlInput,
+      url_proxy: urlProxyInput,
       type: typeInput.value
     }
 
@@ -329,6 +359,7 @@ export class AdminTaskersEdit extends Component {
     this.setState({
       descriptionInput: '',
       urlInput: '',
+      urlProxyInput: '',
       disableInteraction: false,
       nameInput: ''
     })


### PR DESCRIPTION
For tasking managers behind firewalls, we can use a proxy URL to host an API. The projects will still use `url`, but the clock process will use `url_proxy`.  