### PR TITLE
Remove MVT artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Remove MVT artifacts produced by OSMesa in Leaflet fallback maps 
+
 ## v1 - 2019-02-14
 ### Added
 - Scoreboard backend
@@ -108,7 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The first release
 
-[Unreleased]: https://github.com/developmentseed/scoreboard/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/developmentseed/scoreboard/compare/v1...HEAD
+[v0.1]: https://github.com/developmentseed/scoreboard/compare/v0.2.4...v1
 [v0.2.4]: https://github.com/developmentseed/scoreboard/compare/v0.2.3...v0.2.4
 [v0.2.3]: https://github.com/developmentseed/scoreboard/compare/v0.2.2...v0.2.3
 [v0.2.2]: https://github.com/developmentseed/scoreboard/compare/v0.2.1...v0.2.2

--- a/components/charts/LeafletUserExtentMap.js
+++ b/components/charts/LeafletUserExtentMap.js
@@ -19,6 +19,7 @@ class LeafletUserExtentMap extends Component {
       vectorTileLayerStyles['earthquakes'] = styleFunc
     } else {
       vectorTileLayerStyles[this.props.uid] = styleFunc
+      vectorTileLayerStyles['__sequences__'] = () => ({ opacity: 0 })
     }
 
     const options = {


### PR DESCRIPTION
OSMesa produces a __sequences__ layer for housekeeping.
react-leaflet-vectorgrid seems to display these even if there is no
style func associated with that layer. We set the style func for the
sequences layer to 0 opacity