### PR TITLE
Leave excluded users' edits in aggregate statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Leave excluded users' edits in aggregate statistics
+
 ## [v1.0.3] - 2019-03-07
 
 ### Fixed

--- a/api/src/models/userCountryEdits.js
+++ b/api/src/models/userCountryEdits.js
@@ -42,7 +42,6 @@ function getNumberOfParticipants (country_name) {
 
 function getTotalEdits (country_name) {
   return db('user_country_edits')
-    .innerJoin(exclusionList.includedUsers().as('users'), 'user_id', 'users.id')
     .sum('user_country_edits.edit_count as editCount')
     .where('country_name', 'ilike', country_name).debug()
 }


### PR DESCRIPTION
This will keep the aggregate country edit count consistent with the OSMESA statistics in the blurb