### PR TITLE
All campaigns in dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-node_modules
 .DS_Store
 yarn.lock
 package-lock.json
@@ -12,3 +11,7 @@ users.csv
 .vscode
 docs-build
 .swp
+
+# ignore node_modules symlink
+node_modules
+node_modules.nosync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- On user page and dashboard, top campaigns will now show names of campaigns contributed to instead of hashtags contributed to
+
+### Changed
+- On the user dashboard, the "all campaigns" component will show all campaigns contributed to instead of assignments + favorites
 
 ### Fixed
 - Leave excluded users' edits in aggregate statistics

--- a/README.md
+++ b/README.md
@@ -85,13 +85,9 @@ You can rollback migrations with `yarn rollback`.
 ### Populate Data
 For the frontend and the API to work, you must have the data loaded on the local database.
 
-To generate fake user data run:
+To generate fake user and campaign data run:
 
      $ yarn seed
-
-To populate tasking manager data run: 
-
-     $ yarn clocks 
 
 ### Create an admin user
 

--- a/api/src/db/seeds/development/campaigns.js
+++ b/api/src/db/seeds/development/campaigns.js
@@ -1,0 +1,38 @@
+const yakbak = require('yakbak')
+const path = require('path')
+const http = require('http')
+const tmWorker = require('../../../tm_clock')
+
+exports.seed = async (knex) => {
+  /**
+   * We create a tm proxy for tapes and fill the database with real
+   * tasking manager data
+   */
+  const tm3proxy = http.createServer(yakbak('https://tasks.openstreetmap.us', {
+    dirname: path.join(__dirname, '..', '..', '..', '..', 'tests', 'tapes')
+  }))
+
+  await new Promise((resolve, reject) => {
+    tm3proxy.listen(4850, async () => {
+      try {
+        await knex('campaigns').del()
+        await knex('taskers').del()
+
+        // Add tasking managers
+        await knex('taskers').insert({ type: 'tm3', url: 'http://localhost:4850', name: 'test tm3' })
+        await tmWorker()
+
+        // Make all the hashtags predictable
+        const campaigns = await knex('campaigns').select()
+        const fixedCampaigns = campaigns.map(c => knex('campaigns').where('id', c.id).update({
+          campaign_hashtag: `project-${c.tm_id}`
+        }))
+        await Promise.all(fixedCampaigns)
+
+        resolve()
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }).then(() => tm3proxy.close())
+}

--- a/api/src/db/seeds/development/users.js
+++ b/api/src/db/seeds/development/users.js
@@ -1,4 +1,6 @@
 const generateUsers = require('../utils').generateUsers
+const usersClock = require('../../../users_clock')
 
 exports.seed = (knex) => knex('users').del() // delete entries
   .then(() => knex('users').insert(generateUsers(30, knex)))
+  .then(usersClock)

--- a/api/src/db/seeds/utils.js
+++ b/api/src/db/seeds/utils.js
@@ -37,18 +37,18 @@ function generateOSMesaUser (id, name) {
 
   const randomInt = () => parseInt(Math.floor(rand.random() * 1000000))
 
-  for (let i = 1; i < Math.floor(rand.random() * 20); i++) {
+  for (let i=20; i < 120; i++) {
+    editedHashtags.push({
+      'tag': `project-${i}`,
+      'count': Math.floor(rand.random() * 1000)
+    })
+  }
+
+  for (let i = 1; i < Math.floor(rand.random() * 30); i++) {
     let index = Math.floor(rand.random() * (countries.length - 1))
     editedCountries.push({
       'name': countries[index].name,
       'count': Math.floor(rand.random() * 100)
-    })
-
-    let hashtagIndex = Math.floor(rand.random() * 100)
-
-    editedHashtags.push({
-      'tag': `project-${hashtagIndex}`,
-      'count': Math.floor(rand.random() * 1000)
     })
   }
 

--- a/api/src/db/seeds/utils.js
+++ b/api/src/db/seeds/utils.js
@@ -37,7 +37,7 @@ function generateOSMesaUser (id, name) {
 
   const randomInt = () => parseInt(Math.floor(rand.random() * 1000000))
 
-  for (let i=20; i < 120; i++) {
+  for (let i = 20; i < 120; i++) {
     editedHashtags.push({
       'tag': `project-${i}`,
       'count': Math.floor(rand.random() * 1000)

--- a/api/src/db/seeds/utils.js
+++ b/api/src/db/seeds/utils.js
@@ -39,14 +39,15 @@ function generateOSMesaUser (id, name) {
 
   for (let i = 1; i < Math.floor(rand.random() * 20); i++) {
     let index = Math.floor(rand.random() * (countries.length - 1))
-
     editedCountries.push({
       'name': countries[index].name,
       'count': Math.floor(rand.random() * 100)
     })
 
+    let hashtagIndex = Math.floor(rand.random() * 100)
+
     editedHashtags.push({
-      'tag': `project-${i}`,
+      'tag': `project-${hashtagIndex}`,
       'count': Math.floor(rand.random() * 1000)
     })
   }

--- a/api/src/routes/user.js
+++ b/api/src/routes/user.js
@@ -10,6 +10,7 @@ const osmesa = require('../services/osmesa')
 const { canEditUser } = require('../passport')
 const db = require('../db/connection')
 const getCountriesEdited = require('../utils/getCountriesEdited')
+const { prop } = require('ramda')
 
 /**
  * User Stats Route
@@ -133,6 +134,9 @@ async function get (req, res) {
     console.error(err)
   }
 
+  //
+  let allCampaigns = await db('campaigns').whereIn('campaign_hashtag', osmesaData.hashtags.map(prop('tag')))
+
   return res.send({
     id,
     uid,
@@ -140,6 +144,7 @@ async function get (req, res) {
     teams,
     assignments,
     favorites,
+    allCampaigns,
     records: osmesaData,
     roles: rolesList,
     countriesEdited,

--- a/components/AssignmentsTable.js
+++ b/components/AssignmentsTable.js
@@ -3,7 +3,7 @@ import Link from './Link'
 
 export default ({ assignments }) => {
   return (
-    <div className='widget'>
+    <div className='widget assignments-table'>
       <table>
         <thead>
           <tr>

--- a/components/charts/CampaignsChart.js
+++ b/components/charts/CampaignsChart.js
@@ -1,19 +1,35 @@
 import React from 'react'
 import { ResponsiveBar } from '@nivo/bar'
-import { sortBy, map, slice, compose, prop, reverse } from 'ramda'
+import { sortBy, slice, compose, prop, reverse } from 'ramda'
+import getTspanGroups from '../../lib/utils/getTspanGroups'
 
 /**
  * chartify
  * Takes props and turns them into chart data
  * @param {*} props
  */
-function chartify ({ hashtags }) {
+function chartify ({ campaigns, hashtags }) {
+  // merge campaigns and hashtags
+  let contributed = []
+  for (let i = 0; i < campaigns.length; i++) {
+    let tag = campaigns[i].campaign_hashtag
+    let hashtag = hashtags.find(h => {
+      return h.tag === tag
+    })
+    if (hashtag) {
+      contributed.push({
+        id: campaigns[i].name,
+        edits: hashtag.count
+      })
+    }
+  }
+
   return compose(
-    slice(0, 4),
-    map(({ tag, count }) => { return { id: tag, edits: count } }),
     reverse,
-    sortBy(prop('count'))
-  )(hashtags)
+    slice(0, 4),
+    reverse,
+    sortBy(prop('edits'))
+  )(contributed)
 }
 const theme = {
   axis: {
@@ -39,6 +55,38 @@ export default function CampaignCharts (props) {
               'right': 60,
               'bottom': 50,
               'left': 120
+            }}
+            axisLeft={{
+              tickSize: 0,
+              tickPadding: 25,
+              tickRotation: 0,
+              renderTick: ({
+                opacity,
+                textAnchor,
+                textBaseline,
+                textX,
+                textY,
+                theme,
+                value,
+                x,
+                y
+              }) => {
+                return (
+                  <g
+                    transform={`translate(${x},${y})`}
+                    style={{ opacity }}
+                  >
+                    <text
+                      alignmentBaseline={textBaseline}
+                      style={theme.axis.ticks.text}
+                      textAnchor={textAnchor}
+                      transform={`translate(${textX},${textY})`}
+                    >
+                      {getTspanGroups(value, 20)}
+                    </text>
+                  </g>
+                )
+              }
             }}
             theme={theme}
             padding={0.1}

--- a/components/dashboard/DashboardAssignments.js
+++ b/components/dashboard/DashboardAssignments.js
@@ -19,7 +19,7 @@ class DashboardAssignments extends Component {
   }
 
   render () {
-    const { favorites, assignments, authenticatedUser } = this.props
+    const { favorites, assignments, authenticatedUser, all } = this.props
 
     const assignmentFilters = [
       { name: 'Teams', id: 'teams' },
@@ -39,7 +39,7 @@ class DashboardAssignments extends Component {
     const allCampaigns = {
       favorites: sortBy(prop('priority'), favorites),
       teams: teamAssignments,
-      all: teamAssignments.concat(favorites)
+      all
     }
 
     const assignmentsTable = allCampaigns[this.state.assignmentsFilter].map((assignment) => {

--- a/lib/utils/getTspanGroups.js
+++ b/lib/utils/getTspanGroups.js
@@ -1,0 +1,44 @@
+/**
+ * From https://github.com/plouc/nivo/issues/353#issuecomment-456163387
+ * Turns labels in nivo charts to multi-line tspans
+ *
+ * @param {String} value Label in chart
+ * @param {Number} maxLineLength Line length for label
+ */
+export default function getTspanGroups (value, maxLineLength) {
+  const words = value.split(' ')
+  const maxLines = 2
+
+  const assembleLines = words.reduce((acc, word) => {
+    if ((word + acc.currLine).length > maxLineLength && acc.currLine !== '') {
+      return {
+        lines: acc.lines.concat([acc.currLine]),
+        currLine: word
+      }
+    }
+    return {
+      ...acc,
+      currLine: acc.currLine + ' ' + word
+    }
+  },
+  { lines: [], currLine: '' })
+
+  const allLines = assembleLines.lines.concat([assembleLines.currLine])
+
+  const lines = allLines.slice(0, maxLines)
+  let children = []
+  let dy = 0
+
+  lines.forEach((lineText, i) => {
+    children.push(
+      <tspan x={0} dy={dy} key={i}>
+        {
+          (i === 1 && allLines.length > 2) ? lineText.slice(0, maxLineLength - 3) + '...' : lineText
+        }
+      </tspan>
+    )
+    dy += 15
+  })
+
+  return children
+}

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "date-fns": "^1.29.0",
     "debounce-promise": "^3.0.2",
     "directory-command": "^4.0.1",
-    "dotenv": "^6.1.0",
+    "dotenv": "^6.2.0",
     "dotenv-webpack": "^1.5.7",
     "enzyme": "^3.7.0",
     "express": "^4.16.3",

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -132,7 +132,7 @@ class Dashboard extends Component {
           <div className='row'>
             <div className='widget-container'>
               <div className='widget-66'>
-                <CampaignsChart hashtags={hashtags} height='260px' />
+                <CampaignsChart campaigns={allCampaigns} hashtags={hashtags} height='260px' />
               </div>
               <div className='widget-33'>
                 <EditBreakdownChart {...breakdownChartProps} height='260px' />

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -56,7 +56,7 @@ class Dashboard extends Component {
     }
     const { authenticatedUser } = this.props
     const { loggedIn, account } = authenticatedUser
-    const { assignments, favorites, country } = account
+    const { assignments, favorites, country, allCampaigns } = account
 
     const { badges, teams } = account
     const osmesaData = account.records
@@ -118,7 +118,7 @@ class Dashboard extends Component {
         <section className='section--dark'>
           <div className='row'>
             {isAdmin(authenticatedUser.account.roles) && this.renderAdmin()}
-            <DashboardAssignments favorites={favorites} assignments={assignments} authenticatedUser={authenticatedUser} />
+            <DashboardAssignments favorites={favorites} assignments={assignments} authenticatedUser={authenticatedUser} all={allCampaigns} />
           </div>
         </section>
         <section>

--- a/pages/user.js
+++ b/pages/user.js
@@ -28,7 +28,7 @@ export class User extends Component {
 
   render () {
     if (!this.props.user) return <div />
-    const { records, country, badges, teams } = this.props.user
+    const { records, country, badges, teams, allCampaigns } = this.props.user
     const { extent_uri, uid } = records
     if (!records) return <div />
     const editCount = getSumEdits(records)
@@ -78,7 +78,7 @@ export class User extends Component {
           <div className='row'>
             <div className='widget-container'>
               <div className='widget-66'>
-                <CampaignsChart hashtags={hashtags} height='260px' />
+                <CampaignsChart hashtags={hashtags} campaigns={allCampaigns} height='260px' />
               </div>
               <div className='widget-33'>
                 <EditBreakdownChart {...breakdownChartProps} height='260px' />

--- a/styles/Dashboard.scss
+++ b/styles/Dashboard.scss
@@ -457,6 +457,7 @@
   }
 }
 
+/// Dashboard Tables ///
 .filter-bar {
   margin-bottom: 20px;
 
@@ -486,14 +487,16 @@
     }
   }
 }
-
+.assignments-table {
+  max-height: 28rem;
+  overflow-y: scroll;
+}
 .data-not-available {
   font-family: $heading-font-family;
   background-color: #efefea;
   padding: 10px;
   margin-bottom: 30px;
 }
-
 .header-link {
   color: #292929;
 


### PR DESCRIPTION
This PR:

- Fixes the seeds so that you don't need to run clocks anymore, `yarn seed` will run both the tm clock and user clock in development and prefill the database with data
- Creates an `allCampaigns` item in the user API response for the dashboard. Campaigns are joined with the osmesa hashtags to produce `allCampaigns` which are campaigns that a user has worked on.
- Displays the allCampaigns in the Campaigns table instead of the concatenation of assignments and favorites.

**Next steps**:
@LanesGood we should design the table for allCampaigns to have a fixed height and be scrollable with more rows. Let me know if you need running this PR