### PR TITLE
Environment variable for TM name in "Not logged in" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add "Help" link to Scoreboard documentation 
 - Users are able to download a PDF certificate of all their earned badges from their dashboard
 
+### Changed
+- "Not Logged In" error page takes an environment variable for the TM name (default is OSM)
+
 ## [v1.1.0] - 2019-03-19
 ### Added
 - Add OSMESA status as "Last Refreshed" to pages using OSMESA stats

--- a/components/NotLoggedIn.js
+++ b/components/NotLoggedIn.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Link from './Link'
 
 export default ({ message }) => {
+  const tmName = process.env.TM_NAME || 'OSM'
   return (
     <div>
       <section>
@@ -9,7 +10,7 @@ export default ({ message }) => {
           <h2 className='header--large'>You are not logged in!</h2>
           <p>
             <Link href='/auth/openstreetmap'>
-              <a className='link--large'>{message || 'Log in with your OSM account'}</a>
+              <a className='link--large'>{message || `Log in with your ${tmName} account`}</a>
             </Link>
           </p>
         </div>


### PR DESCRIPTION
Parameterize TM name when displaying the Not Logged In message