### PR TITLE
Fix/235 campaign navigation

### DIFF
--- a/components/Link.js
+++ b/components/Link.js
@@ -4,8 +4,12 @@ import { APP_URL_PREFIX } from '../api/src/config'
 
 export default class NewLink extends Link {
   render () {
-    const { href } = this.props
+    const { href, as } = this.props
     const newHref = join(APP_URL_PREFIX, href)
-    return <Link {...this.props} href={newHref} />
+    let newAs
+    if (as) {
+      newAs = join(APP_URL_PREFIX, as)
+    }
+    return <Link {...this.props} href={newHref} as={newAs} />
   }
 }

--- a/components/campaigns/CampaignCard.js
+++ b/components/campaigns/CampaignCard.js
@@ -20,7 +20,7 @@ export default ({ campaign }) => {
     team_priority
   } = campaign
   return (
-    <Link href={`/campaigns/${tasker_id}-${tm_id}`}>
+    <Link href={`/campaign?id=${tasker_id}-${tm_id}`} as={`/campaigns/${tasker_id}-${tm_id}`}>
       <a className='card--wrapper'>
         <div className='card'>
           <div className='map-campaign-sm'><CampaignMap feature={JSON.parse(geometry)} interactive={false} /></div>

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -3,7 +3,7 @@ import InputRange from 'react-input-range'
 import Select from 'react-select'
 import join from 'url-join'
 import { APP_URL_PREFIX } from '../../api/src/config'
-import { campaignFiltersInitialState } from '../../lib/store/actions/campaigns';
+import { campaignFiltersInitialState } from '../../lib/store/actions/campaigns'
 import { equals } from 'ramda'
 
 const searchIcon = join(APP_URL_PREFIX, '/static/magnifier-left.svg')

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -6,38 +6,30 @@ import { APP_URL_PREFIX } from '../../api/src/config'
 
 const searchIcon = join(APP_URL_PREFIX, '/static/magnifier-left.svg')
 
-export default class extends React.Component {
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      compl_min: 0,
-      compl_max: 100,
-      valid_min: 0,
-      valid_max: 100
-    }
-  }
-
+export default class Filters extends React.Component {
   render () {
     const {
       handleSearch,
+      searchText,
       selectedTM,
       handleSelectTM,
       sortOrder,
       tmList,
       handleCompletenessChange,
       handleValidationChange,
-      handleSortChange
+      handleSortChange,
+      complMin,
+      complMax,
+      validMin,
+      validMax
     } = this.props
-
-    let { compl_min, compl_max, valid_min, valid_max } = this.state
 
     return (
       <form className='filters' onSubmit={e => e.preventDefault()}>
         <fieldset>
           <legend>Search</legend>
           <div className='search'>
-            <input className='input--text' onChange={handleSearch} />
+            <input className='input--text' value={searchText} onChange={handleSearch} />
             <span className='search-icon' style={{ backgroundImage: `url(${searchIcon})` }} />
           </div>
         </fieldset>
@@ -74,9 +66,8 @@ export default class extends React.Component {
           <InputRange
             maxValue={100}
             minValue={0}
-            value={{ min: compl_min, max: compl_max }}
-            onChange={({ min, max }) => this.setState({ compl_min: min, compl_max: max })}
-            onChangeComplete={handleCompletenessChange}
+            value={{ min: complMin, max: complMax }}
+            onChange={handleCompletenessChange}
           />
         </fieldset>
         <fieldset>
@@ -84,9 +75,8 @@ export default class extends React.Component {
           <InputRange
             maxValue={100}
             minValue={0}
-            value={{ min: valid_min, max: valid_max }}
-            onChange={({ min, max }) => this.setState({ valid_min: min, valid_max: max })}
-            onChangeComplete={handleValidationChange}
+            value={{ min: validMin, max: validMax }}
+            onChange={handleValidationChange}
           />
         </fieldset>
       </form>

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -3,6 +3,8 @@ import InputRange from 'react-input-range'
 import Select from 'react-select'
 import join from 'url-join'
 import { APP_URL_PREFIX } from '../../api/src/config'
+import { campaignFiltersInitialState } from '../../lib/store/actions/campaigns';
+import { equals } from 'ramda'
 
 const searchIcon = join(APP_URL_PREFIX, '/static/magnifier-left.svg')
 
@@ -22,8 +24,20 @@ export default class Filters extends React.Component {
       complMax,
       validMin,
       validMax,
-      handleClick
+      handleReset
     } = this.props
+
+    const isReset = equals(
+      campaignFiltersInitialState, {
+        searchText,
+        compl_min: complMin,
+        compl_max: complMax,
+        valid_min: validMin,
+        valid_max: validMax,
+        selectedTM,
+        sortOrder,
+        page: 1
+      })
 
     return (
       <form className='filters' onSubmit={e => e.preventDefault()}>
@@ -80,9 +94,12 @@ export default class Filters extends React.Component {
             onChange={handleValidationChange}
           />
         </fieldset>
-        <div className='reset'>
-          <a href='#' className='link--normal' onClick={handleClick}><legend>&#10005; Reset Filters</legend></a>
-        </div>
+        {
+          !isReset &&
+          <div className='reset'>
+            <div className='link--normal' onClick={handleReset}><legend>&#10005; Reset Filters</legend></div>
+          </div>
+        }
       </form>
     )
   }

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -21,7 +21,8 @@ export default class Filters extends React.Component {
       complMin,
       complMax,
       validMin,
-      validMax
+      validMax,
+      handleClick
     } = this.props
 
     return (
@@ -79,6 +80,9 @@ export default class Filters extends React.Component {
             onChange={handleValidationChange}
           />
         </fieldset>
+        <div className='reset'>
+          <a href='#' className='link--normal' onClick={handleClick}><legend>&#10005; Reset Filters</legend></a>
+        </div>
       </form>
     )
   }

--- a/lib/store/actions/campaigns.js
+++ b/lib/store/actions/campaigns.js
@@ -1,7 +1,7 @@
 import fetch, { createApiUrl } from '../../utils/api'
+import debounce from 'lodash.debounce'
 
-function updateCampaigns (store, storeData) {
-  store.setState({ campaigns: { ...storeData, apiStatus: 'LOADING' } })
+const updateCampaigns = debounce((store, filters) => {
   let {
     searchText: q,
     page,
@@ -11,61 +11,75 @@ function updateCampaigns (store, storeData) {
     valid_max,
     selectedTM: tm,
     sortOrder: sortType
-  } = storeData
+  } = filters
 
   fetch(createApiUrl('/api/campaigns', { q, page, tm, compl_min, compl_max, valid_min, valid_max, sortType }))
     .then(async res => {
       const records = await res.json()
-      store.setState({ campaigns: { ...storeData, apiStatus: 'SUCCESS', records } })
+      store.setState({ campaignSearchResults: { apiStatus: 'SUCCESS', records } })
     })
     .catch(err => {
       console.error(err)
-      store.setState({ campaigns: { ...storeData, apiStatus: 'ERROR' } })
+      store.setState({ campaignSearchResults: { apiStatus: 'ERROR' } })
       store.setState({ notification: { type: 'error', message: err.message } })
     })
-}
+}, 1000)
 
 export default store => ({
   handleCampaignsSearch (state, value) {
-    const { campaigns } = state
-    campaigns.page = 1
-    campaigns.searchText = value
-    updateCampaigns(store, campaigns)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, { page: 1, searchText: value })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   },
 
   handleCampaignsSortChange (state, value) {
-    const { campaigns } = state
-    campaigns.sortOrder = value
-    updateCampaigns(store, campaigns)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, { sortOrder: value })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   },
 
   handleSelectTM (state, selectedValue) {
-    const { campaigns } = state
-    campaigns.selectedTM = selectedValue
-    updateCampaigns(store, campaigns)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, { selectedTM: selectedValue })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   },
 
   handleCampaignsPageChange (state, page) {
-    const { campaigns } = state
-    campaigns.page = page
-    updateCampaigns(store, campaigns)
+    console.log(page)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, { page })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   },
 
   handleCampaignsCompletenessChange (state, completeness) {
-    const { campaigns } = state
-    const { min: compl_min, max: compl_max } = completeness
-    campaigns.page = 1
-    campaigns.compl_min = compl_min
-    campaigns.compl_max = compl_max
-    updateCampaigns(store, campaigns)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, {
+      compl_min: completeness.min,
+      compl_max: completeness.max,
+      page: 1
+    })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   },
 
   handleCampaignsValidationChange (state, validation) {
-    const { campaigns } = state
-    const { min: valid_min, max: valid_max } = validation
-    campaigns.page = 1
-    campaigns.valid_min = valid_min
-    campaigns.valid_max = valid_max
-    updateCampaigns(store, campaigns)
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, {
+      valid_min: validation.min,
+      valid_max: validation.max,
+      page: 1
+    })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
   }
 })

--- a/lib/store/actions/campaigns.js
+++ b/lib/store/actions/campaigns.js
@@ -1,6 +1,22 @@
 import fetch, { createApiUrl } from '../../utils/api'
 import debounce from 'lodash.debounce'
 
+export const campaignFiltersInitialState = {
+  searchText: '',
+  compl_min: 0,
+  compl_max: 100,
+  valid_min: 0,
+  valid_max: 100,
+  selectedTM: null,
+  sortOrder: null,
+  page: 1
+}
+
+export const campaignSearchInitialState = {
+  apiStatus: 'LOADING',
+  records: {}
+}
+
 const updateCampaigns = debounce((store, filters) => {
   let {
     searchText: q,
@@ -36,7 +52,7 @@ export default store => ({
 
   handleCampaignsSortChange (state, value) {
     const { campaigns, campaignSearchResults: { records } } = state
-    const newFilters = Object.assign({}, campaigns, { sortOrder: value })
+    const newFilters = Object.assign({}, campaigns, { page: 1, sortOrder: value })
     store.setState({ campaigns: newFilters })
     store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
     updateCampaigns(store, newFilters)
@@ -44,14 +60,13 @@ export default store => ({
 
   handleSelectTM (state, selectedValue) {
     const { campaigns, campaignSearchResults: { records } } = state
-    const newFilters = Object.assign({}, campaigns, { selectedTM: selectedValue })
+    const newFilters = Object.assign({}, campaigns, { page: 1, selectedTM: selectedValue })
     store.setState({ campaigns: newFilters })
     store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
     updateCampaigns(store, newFilters)
   },
 
   handleCampaignsPageChange (state, page) {
-    console.log(page)
     const { campaigns, campaignSearchResults: { records } } = state
     const newFilters = Object.assign({}, campaigns, { page })
     store.setState({ campaigns: newFilters })
@@ -78,6 +93,14 @@ export default store => ({
       valid_max: validation.max,
       page: 1
     })
+    store.setState({ campaigns: newFilters })
+    store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
+    updateCampaigns(store, newFilters)
+  },
+
+  handleCampaignsFiltersReset (state) {
+    const { campaigns, campaignSearchResults: { records } } = state
+    const newFilters = Object.assign({}, campaigns, campaignFiltersInitialState)
     store.setState({ campaigns: newFilters })
     store.setState({ campaignSearchResults: { apiStatus: 'LOADING', records } })
     updateCampaigns(store, newFilters)

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -1,7 +1,7 @@
 import createStore from 'unistore'
 import usersActions from './actions/users'
 import campaignActions from './actions/campaign'
-import campaignsActions from './actions/campaigns'
+import campaignsActions, { campaignFiltersInitialState, campaignSearchInitialState } from './actions/campaigns'
 import countriesActions from './actions/countries'
 import badgesActions from './actions/badges'
 import teamsActions from './actions/teams'
@@ -68,18 +68,8 @@ export const InitialState = {
     creationDate: Date.now(),
     refreshDate: Date.now()
   },
-  campaigns: {
-    searchText: '',
-    compl_min: 0,
-    compl_max: 100,
-    valid_min: 0,
-    valid_max: 100,
-    page: 1
-  },
-  campaignSearchResults: {
-    apiStatus: 'LOADING',
-    records: {}
-  },
+  campaigns: campaignFiltersInitialState,
+  campaignSearchResults: campaignSearchInitialState,
   notification: null
 }
 

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -74,7 +74,9 @@ export const InitialState = {
     compl_max: 100,
     valid_min: 0,
     valid_max: 100,
-    page: 1,
+    page: 1
+  },
+  campaignSearchResults: {
     apiStatus: 'LOADING',
     records: {}
   },

--- a/lib/store/with-store.js
+++ b/lib/store/with-store.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import devtools from 'unistore/devtools'
 import { initializeStore } from './'
 
 const isServer = typeof window === 'undefined'
@@ -12,7 +13,8 @@ function getOrCreateStore (initialState) {
 
   // Create store if unavailable on the client and set it on the window object
   if (!window[__NEXT_REDUX_STORE__]) {
-    window[__NEXT_REDUX_STORE__] = initializeStore(initialState)
+    let store = process.env.NODE_ENV === 'production' ? initializeStore(initialState) : devtools(initializeStore(initialState))
+    window[__NEXT_REDUX_STORE__] = store
   }
   return window[__NEXT_REDUX_STORE__]
 }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "leaflet": "^1.4.0",
     "leaflet.vectorgrid": "^1.3.0",
     "lodash-es": "^4.17.5",
+    "lodash.debounce": "^4.0.8",
     "mapbox-gl": "^0.53.0",
     "next": "^7.0.2",
     "next-images": "^1.0.1",

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -179,11 +179,16 @@ const Page = connect(
   actions
 )(Campaign)
 
-Page.getInitialProps = async ({ req }) => {
-  const { id } = req.params
-  return {
-    id
+export default Page
+
+Page.getInitialProps = ({ query }) => {
+  if (query) {
+    const { id } = query
+    return {
+      id
+    }
+  } else {
+    return {}
   }
 }
 
-export default Page

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -191,4 +191,3 @@ Page.getInitialProps = ({ query }) => {
     return {}
   }
 }
-

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import queryString from 'query-string'
 import Pagination from 'react-js-pagination'
 import CampaignFilters from '../components/campaigns/CampaignFilters'
 import CampaignsListing from '../components/campaigns/CampaignsListing'
@@ -40,17 +39,14 @@ export class Campaigns extends Component {
   }
 
   handlePageChange (pageNumber) {
-    this.setState({ records: {} })
     window.scrollTo(0, 0)
     this.props.handleCampaignsPageChange(pageNumber || 1)
   }
 
   componentDidMount () {
-    if (this.props.location) {
-      let { page } = queryString.parse(this.props.location.search)
-      this.props.handleCampaignsPageChange(page || 1)
-    } else {
-      this.props.handleCampaignsPageChange(1)
+    console.log(this.props.campaignSearchResults)
+    if (!this.props.campaignSearchResults || !Object.keys(this.props.campaignSearchResults.records).length) {
+      this.props.handleCampaignsPageChange(this.props.page || 1)
     }
   }
 
@@ -58,11 +54,19 @@ export class Campaigns extends Component {
     const {
       page,
       searchText,
-      records: { total, records, allCount, tms, refreshDate },
-      apiStatus,
       selectedTM,
+      compl_min,
+      compl_max,
+      valid_min,
+      valid_max,
       sortOrder
     } = this.props.campaigns
+
+    const {
+      records: { total, records, allCount, tms, refreshDate },
+      apiStatus
+    } = this.props.campaignSearchResults
+
     if (!records) {
       return <div />
     }
@@ -92,6 +96,10 @@ export class Campaigns extends Component {
                 handleSortChange={this.handleCampaignsSortChange}
                 handleSelectTM={this.handleSelectTM}
                 tmList={tms}
+                complMin={compl_min}
+                complMax={compl_max}
+                validMin={valid_min}
+                validMax={valid_max}
                 selectedTM={selectedTM}
                 sortOrder={sortOrder}
                 handleSearch={this.handleSearch}
@@ -115,4 +123,4 @@ export class Campaigns extends Component {
   }
 };
 
-export default connect(['campaigns'], actions)(Campaigns)
+export default connect(['campaigns', 'campaignSearchResults'], actions)(Campaigns)

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -44,7 +44,6 @@ export class Campaigns extends Component {
   }
 
   componentDidMount () {
-    console.log(this.props.campaignSearchResults)
     if (!this.props.campaignSearchResults || !Object.keys(this.props.campaignSearchResults.records).length) {
       this.props.handleCampaignsPageChange(this.props.page || 1)
     }

--- a/pages/campaigns.js
+++ b/pages/campaigns.js
@@ -16,6 +16,7 @@ export class Campaigns extends Component {
     this.handleSelectTM = this.handleSelectTM.bind(this)
     this.handleSearch = this.handleSearch.bind(this)
     this.handleCampaignsSortChange = this.handleCampaignsSortChange.bind(this)
+    this.handleReset = this.handleReset.bind(this)
   }
 
   handleSearch (event) {
@@ -43,6 +44,10 @@ export class Campaigns extends Component {
     this.props.handleCampaignsPageChange(pageNumber || 1)
   }
 
+  handleReset () {
+    this.props.handleCampaignsFiltersReset()
+  }
+
   componentDidMount () {
     if (!this.props.campaignSearchResults || !Object.keys(this.props.campaignSearchResults.records).length) {
       this.props.handleCampaignsPageChange(this.props.page || 1)
@@ -65,10 +70,6 @@ export class Campaigns extends Component {
       records: { total, records, allCount, tms, refreshDate },
       apiStatus
     } = this.props.campaignSearchResults
-
-    if (!records) {
-      return <div />
-    }
 
     return (
       <div className='Campaigns'>
@@ -94,7 +95,8 @@ export class Campaigns extends Component {
                 handleValidationChange={this.handleValidationChange}
                 handleSortChange={this.handleCampaignsSortChange}
                 handleSelectTM={this.handleSelectTM}
-                tmList={tms}
+                handleReset={this.handleReset}
+                tmList={tms || []}
                 complMin={compl_min}
                 complMax={compl_max}
                 validMin={valid_min}
@@ -106,14 +108,19 @@ export class Campaigns extends Component {
               />
             </div>
             <div className='widget-75'>
-              <CampaignsListing records={records} apiStatus={apiStatus} total={total} allCount={allCount} />
-              <Pagination
-                activePage={page}
-                itemsCountPerPage={10}
-                totalItemsCount={total}
-                pageRangeDisplayed={5}
-                onChange={this.handlePageChange}
-              />
+              {
+                records &&
+                <>
+                  <CampaignsListing records={records} apiStatus={apiStatus} total={total} allCount={allCount} />
+                  <Pagination
+                    activePage={page}
+                    itemsCountPerPage={10}
+                    totalItemsCount={total}
+                    pageRangeDisplayed={5}
+                    onChange={this.handlePageChange}
+                  />
+                </>
+              }
             </div>
           </div>
         </section>

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -886,6 +886,7 @@ form.filters {
   }
   .reset {
     display: inline-block;
+    cursor: pointer;
     flex: 100%;
   }
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -871,14 +871,22 @@ form.filters {
   @include media(small-only) {
     flex-direction: row;
     margin-bottom: 1em;
+    flex-wrap: wrap;
   }
   fieldset {
     width: 100%;
+    @include media(small-only) {
+      flex: 1;
+    }
     &~fieldset {
       @include media(small-only) {
         margin-left: .7em;
       }
     }
+  }
+  .reset {
+    display: inline-block;
+    flex: 100%;
   }
 }
 //tables //

--- a/tests/containers.test.js
+++ b/tests/containers.test.js
@@ -18,8 +18,10 @@ function mockAction () {
 it('Campaigns renders without crashing', () => {
   const div = document.createElement('div')
   const campaigns = InitialState.campaigns
+  const campaignSearchResults = InitialState.campaignSearchResults
   const mockProps = {
     campaigns,
+    campaignSearchResults,
     handleCampaignsSearch: mockAction,
     handleCampaignsFilterChange: mockAction,
     handleCampaignsPageChange: mockAction


### PR DESCRIPTION
This fixes #235 

While we have a redux store (using unistore), we never take advantage of the client side routing, so the state gets reset when we navigate from campaigns to campaign because we call an explicit SSR every time through the express server.

- [x] Fix client side routing for campaigns
- [x] Fix filter components to read from state
- [x] Test pagination