### PR TITLE
Don't count excluded users or their edits in top stats on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - State retains page number and filters when navigating between the Campaigns page and individual campaign cards
+- Top stats on the main page no longer count excluded users or their edits
 
 ## [v1.2.0] - 2019-05-08
 ### Added

--- a/api/src/routes/topstats.js
+++ b/api/src/routes/topstats.js
@@ -41,9 +41,9 @@ module.exports = async (req, res) => {
       .orderBy('edit_count', 'desc')
       .limit(10)
 
-    const [{ totalEdits }] = await db('users').sum('edit_count as totalEdits')
+    const [{ totalEdits }] = await db('users').whereNotIn('id', exclusion.list()).sum('edit_count as totalEdits')
 
-    const [{ numUsers }] = await db('users').count('id as numUsers')
+    const [{ numUsers }] = await db('users').whereNotIn('id', exclusion.list()).count('id as numUsers')
     const editsByCountry = await db('user_country_edits')
       .innerJoin(
         db('users').select('id').whereNotIn('id', exclusion.list()).as('users'), 'user_id', 'users.id'


### PR DESCRIPTION
Fixes #369 
✅ Confirmed this was the reason edit totals were different on Home page vs. Users page