### PR TITLE
Feature/combined stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated osm-teams to have access tokens. Admins now need to sign in to osm-teams
 - UI additions to gray out teams if the user does not have an access token
 
+### Changed
+- Stats in the tables, exports and blurbs on Campaign, Dashboard, and User profile pages now combine the `added` and `modified` edits
+
 ## [v1.3.0] - 2019-06-07
 ### Added
 - Campaigns, countries and users pages can be sorted by name in alphabetical order

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Stats in the tables, exports and blurbs on Campaign, Dashboard, and User profile pages now combine the `added` and `modified` edits
 
 ## [v1.3.1] - 2019-06-11
 ### Added
 - Updated osm-teams to have access tokens. Admins now need to sign in to osm-teams
 - UI additions to gray out teams if the user does not have an access token
-
-### Changed
-- Stats in the tables, exports and blurbs on Campaign, Dashboard, and User profile pages now combine the `added` and `modified` edits
 
 ## [v1.3.0] - 2019-06-07
 ### Added

--- a/components/campaign/CampaignBlurb.js
+++ b/components/campaign/CampaignBlurb.js
@@ -4,11 +4,15 @@ import { formatDecimal, formatKm } from '../../lib/utils/format'
 export default function Blurb ({
   users,
   km_roads_add,
+  km_roads_mod,
   buildings_add,
+  buildings_mod,
   poi_add,
-  km_waterways_add,
+  poi_mod,
   km_coastlines_add,
-  km_coastlines_mod
+  km_coastlines_mod,
+  km_waterways_add,
+  km_waterways_mod
 }) {
   if (users.length === 0) {
     return <h2 className='header--small width--shortened list--block'>
@@ -17,6 +21,6 @@ export default function Blurb ({
   }
 
   return <h2 className='header--small width--shortened list--block'>
-    <mark>{users.length}</mark> mappers, mapping <mark>{formatKm(km_roads_add)}</mark> of roads, <mark>{formatDecimal(buildings_add)}</mark> buildings, <mark>{formatDecimal(poi_add)}</mark> Points of Interest, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add)}</mark> of waterways.
+    <mark>{users.length}</mark> mappers, mapping <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways.
   </h2>
 }

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -11,7 +11,11 @@ export default function CampaignTable (props) {
   const campaignTopStats = sortBy(prop('edits'), props.users).reverse()
     .map(user => ({
       ...user,
-      km_coastlines_all: user.km_coastlines_add + user.km_coastlines_mod
+      km_roads_add_mod: user.km_roads_add + user.km_roads_mod,
+      buildings_add_mod: user.buildings_add + user.buildings_mod,
+      poi_add_mod: user.poi_add + user.poi_mod,
+      km_coastlines_add_mod: user.km_coastlines_add + user.km_coastlines_mod,
+      km_waterways_add_mod: user.km_waterways_add + user.km_waterways_mod
     }))
   return (
     <div className='widget clearfix table-wrapper'>
@@ -42,11 +46,11 @@ export default function CampaignTable (props) {
                       </a>
                     </Link>
                   </td>
-                  <td>{formatDecimal(user.km_roads_add)}</td>
-                  <td>{formatDecimal(user.buildings_add)}</td>
-                  <td>{formatDecimal(user.poi_add)}</td>
-                  <td>{formatDecimal(user.km_coastlines_all)}</td>
-                  <td>{formatDecimal(user.km_waterways_add)}</td>
+                  <td>{formatDecimal(user.km_roads_add_mod)}</td>
+                  <td>{formatDecimal(user.buildings_add_mod)}</td>
+                  <td>{formatDecimal(user.poi_add_mod)}</td>
+                  <td>{formatDecimal(user.km_coastlines_add_mod)}</td>
+                  <td>{formatDecimal(user.km_waterways_add_mod)}</td>
                   <td>{formatDecimal(user.edits)}</td>
                   <td>{formatDecimal(user.editSum)}</td>
                 </tr>
@@ -56,11 +60,11 @@ export default function CampaignTable (props) {
       </table>
       <CSVLink className='link--large' style={{ display: 'inline-block', float: 'right', marginTop: '2rem' }} data={campaignTopStats} filename={`${props.name} - Top 10 Participants.csv`} headers={[
         { label: 'Name', key: 'name' },
-        { label: 'Roads (Km)', key: 'km_roads_add' },
-        { label: 'Buildings', key: 'buildings_add' },
-        { label: 'Points of Interest', key: 'poi_add' },
-        { label: 'Coastlines (Km)', key: 'km_coastlines_all' },
-        { label: 'Waterways (Km)', key: 'km_waterways_add' },
+        { label: 'Roads (Km)', key: 'km_roads_add_mod' },
+        { label: 'Buildings', key: 'buildings_add_mod' },
+        { label: 'Points of Interest', key: 'poi_add_mod' },
+        { label: 'Coastlines (Km)', key: 'km_coastlines_add_mod' },
+        { label: 'Waterways (Km)', key: 'km_waterways_add_mod' },
         { label: 'Changesets', key: 'edits' },
         { label: 'Edits', key: 'editSum' }
       ]}>

--- a/components/dashboard/DashboardBlurb.js
+++ b/components/dashboard/DashboardBlurb.js
@@ -5,9 +5,13 @@ import { head } from 'ramda'
 
 export default function Blurb ({
   km_roads_add,
+  km_roads_mod,
   buildings_add,
+  buildings_mod,
   poi_add,
+  poi_mod,
   km_waterways_add,
+  km_waterways_mod,
   km_coastlines_add,
   km_coastlines_mod,
   country_list,
@@ -27,6 +31,6 @@ export default function Blurb ({
   }
 
   return <h2 className='header--small width--shortened list--block'>
-    Since <mark>{firstYearEdited}</mark>, {sentence} <mark>{formatKm(km_roads_add)}</mark> of roads, <mark>{formatDecimal(buildings_add)}</mark> buildings, <mark>{formatDecimal(poi_add)}</mark> Points of Interest, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add)}</mark> of waterways in <mark>{country_list.length}</mark> <mark>{countryWord}</mark>.
+    Since <mark>{firstYearEdited}</mark>, {sentence} <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways in <mark>{country_list.length}</mark> <mark>{countryWord}</mark>.
   </h2>
 }

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -89,17 +89,19 @@ export class Campaign extends Component {
 
   render () {
     const { meta, lastUpdate, creationDate, refreshDate, editSum } = this.props.campaign
-
     const stats = merge({
       users: [],
       km_roads_add: 0,
+      km_roads_mod: 0,
       buildings_add: 0,
+      buildings_mod: 0,
       poi_add: 0,
+      poi_mod: 0,
       km_waterways_add: 0,
+      km_waterways_mod: 0,
       km_coastlines_add: 0,
       km_coastlines_mod: 0
     }, this.props.campaign.stats)
-
     return (
       <div className='Campaigns'>
         <header className='header--internal--green header--page'>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -66,6 +66,14 @@ class Dashboard extends Component {
     const { badges, teams, refreshDate } = account
     const osmesaData = account.records
     const { hashtags, edit_times, extent_uri, uid } = osmesaData
+    const authenticatedUserExport = {
+      ...authenticatedUser,
+      km_roads_add_mod: authenticatedUser.account.records.km_roads_add + authenticatedUser.account.records.km_roads_mod,
+      buildings_add_mod: authenticatedUser.account.records.buildings_add + authenticatedUser.account.records.buildings_mod,
+      poi_add_mod: authenticatedUser.account.records.poi_add + authenticatedUser.account.records.poi_mod,
+      km_coastlines_add_mod: authenticatedUser.account.records.km_coastlines_add + authenticatedUser.account.records.km_coastlines_mod,
+      km_waterways_add_mod: authenticatedUser.account.records.km_waterways_add + authenticatedUser.account.records.km_waterways_mod
+    }
     const breakdownChartProps = pick(
       [
         'waterways_add',
@@ -150,40 +158,41 @@ class Dashboard extends Component {
               className='button button--secondary'
               data={[
                 {
-                  authenticatedUser,
+                  authenticatedUserExport,
                   badgeCount
                 }
               ]}
               headers={[
-                { label: 'Name', key: 'authenticatedUser.osm.displayName' },
+                { label: 'Name', key: 'authenticatedUserExport.osm.displayName' },
                 {
                   label: 'Campaigns',
-                  key: 'authenticatedUser.account.allCampaigns.length'
+                  key: 'authenticatedUserExport.account.allCampaigns.length'
                 },
                 { label: 'Badges', key: 'badgeCount' },
+                { label: 'Countries', key: 'authenticatedUserExport.account.records.country_list.length' },
                 {
                   label: 'Roads (Km)',
-                  key: 'authenticatedUser.account.records.km_roads_add'
+                  key: 'authenticatedUserExport.km_roads_add_mod'
                 },
                 {
                   label: 'Buildings',
-                  key: 'authenticatedUser.account.records.buildings_add'
+                  key: 'authenticatedUserExport.buildings_add_mod'
                 },
                 {
                   label: 'Points of Interest',
-                  key: 'authenticatedUser.account.records.poi_add'
+                  key: 'authenticatedUserExport.poi_add_mod'
                 },
                 {
                   label: 'Coastlines (Km)',
-                  key: 'authenticatedUser.account.records.km_coastlines_add'
+                  key: 'authenticatedUserExport.km_coastlines_add_mod'
                 },
                 {
                   label: 'Waterways (Km)',
-                  key: 'authenticatedUser.account.records.km_waterways_add'
+                  key: 'authenticatedUserExport.km_waterways_add_mod'
                 },
                 {
                   label: 'Total Edits',
-                  key: 'authenticatedUser.account.records.edit_count'
+                  key: 'authenticatedUserExport.account.records.edit_count'
                 }
               ]}
               filename={`${name}_ScoreboardData.csv`}

--- a/pages/user.js
+++ b/pages/user.js
@@ -47,7 +47,14 @@ export class User extends Component {
     const badgeCount = Object.keys(badges.earnedBadges).length
     const campaignCount = records.hashtags.length
     const { name, hashtags, edit_times } = records
-
+    const recordsExport = {
+      ...records,
+      km_roads_add_mod: records.km_roads_add + records.km_roads_mod,
+      buildings_add_mod: records.buildings_add + records.buildings_mod,
+      poi_add_mod: records.poi_add + records.poi_mod,
+      km_coastlines_add_mod: records.km_coastlines_add + records.km_coastlines_mod,
+      km_waterways_add_mod: records.km_waterways_add + records.km_waterways_mod
+    }
     const breakdownChartProps = pick(
       [
         'waterways_add',
@@ -97,20 +104,20 @@ export class User extends Component {
                 {
                   badgeCount,
                   campaignCount,
-                  records
+                  recordsExport
                 }
               ]}
               headers={[
-                { label: 'Name', key: 'records.name' },
+                { label: 'Name', key: 'recordsExport.name' },
                 { label: 'Campaigns', key: 'campaignCount' },
                 { label: 'Badges', key: 'badgeCount' },
-                { label: 'Countries', key: 'records.country_list.length' },
-                { label: 'Roads (Km)', key: 'records.km_roads_add' },
-                { label: 'Buildings', key: 'records.buildings_add' },
-                { label: 'Points of Interest', key: 'records.poi_add' },
-                { label: 'Coastlines (Km)', key: 'records.km_coastlines_add' },
-                { label: 'Waterways (Km)', key: 'records.km_waterways_add' },
-                { label: 'Total Edits', key: 'records.edit_sum' }
+                { label: 'Countries', key: 'recordsExport.country_list.length' },
+                { label: 'Roads (Km)', key: 'recordsExport.km_roads_add_mod' },
+                { label: 'Buildings', key: 'recordsExport.buildings_add_mod' },
+                { label: 'Points of Interest', key: 'recordsExport.poi_add_mod' },
+                { label: 'Coastlines (Km)', key: 'recordsExport.km_coastlines_add_mod' },
+                { label: 'Waterways (Km)', key: 'recordsExport.km_waterways_add_mod' },
+                { label: 'Total Edits', key: 'recordsExport.edit_sum' }
               ]}
               filename={`${name}_ScoreboardData.csv`}
             >


### PR DESCRIPTION
Combines the `add` and `mod` stats for user edits on the Campaign page blurb, table and .csv export, the Dashboard blurb and .csv export, and the User profile blurb and .csv export. Closes #383 

It appears that the stats rendered by the Campaign page blurb are static and randomly generated, while the Campaign page blurb on staging/production is an accurate and dynamic sum of the campaign participants. For now, this means that the campaign page blurb is not a sum of the participants stats, so it is not possible to confirm the accuracy of the calculation. @kamicut can you confirm that this is the case?