### PR TITLE
Close #277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed language related to mapping/completeness percentage between tasking managers 2 and 3
+
 ## [v1.3.3] - 2019-06-26
 ### Added
 - Add changeset counts for user table in country pages

--- a/api/src/services/tm_types/tm2.js
+++ b/api/src/services/tm_types/tm2.js
@@ -95,6 +95,13 @@ class TM2API {
       const {
         created: created_at, last_update: updated_at // eslint-disable-line camelcase
       } = feature.properties
+
+      // In tm2, done is a state such that if a square is validated,
+      // it is no longer counted as 'mapped'. This makes 100% validated
+      // show 0% mapped. To fix this, we reset 'done' to be equal to done + validated
+      // such that 100% validation is 100% completion
+      properties.done = properties.done + properties.validated
+
       return merge(properties, {
         campaign_hashtag: mainHashtag,
         created_at,

--- a/components/campaigns/CampaignCard.js
+++ b/components/campaigns/CampaignCard.js
@@ -52,7 +52,7 @@ export default ({ campaign }) => {
             <ul className='card-stats'>
               <li className='list--inline'>
                 <span className='num--large'>{parseInt(Math.min(100, done), 10)}%</span>
-                <span className='descriptor-chart'>Complete</span>
+                <span className='descriptor-chart'>Mapped</span>
               </li>
               <li className='list--inline'>
                 <span className='num--large'>{parseInt(Math.min(100, validated), 10)}%</span>

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -79,7 +79,7 @@ export default class Filters extends React.Component {
           />
         </fieldset>
         <fieldset>
-          <legend>Completeness</legend>
+          <legend>% Mapped</legend>
           <InputRange
             maxValue={100}
             minValue={0}
@@ -88,7 +88,7 @@ export default class Filters extends React.Component {
           />
         </fieldset>
         <fieldset>
-          <legend>Validation</legend>
+          <legend>% Validated</legend>
           <InputRange
             maxValue={100}
             minValue={0}

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -141,7 +141,7 @@ export class Campaign extends Component {
         </header>
         <ScoreboardPanel title='' facets={
           [
-            { label: 'Complete', value: `${parseInt(meta.done, 10)}%` },
+            { label: 'Mapped', value: `${parseInt(meta.done, 10)}%` },
             { label: 'Validated', value: `${parseInt(meta.validated, 10)}%` },
             { label: 'Participants', value: stats.users.length },
             { label: 'Total features mapped', value: formatDecimal(editSum) }


### PR DESCRIPTION
This fixes issue #277.
<img width="1269" alt="image" src="https://user-images.githubusercontent.com/719357/61246562-1a618680-a71d-11e9-9a44-0eb929a0f625.png">

The new metric is the following mapping to the TM2 and TM3 APIs
For tm2: % mapped is `done + validated`
For tm3: % mapped is `percentMapped`