### PR TITLE
fix/418 Updates the last edit to reflect current math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Edit times that occured within the last 24 hours show 'Last Edit: In the last 24 Hours' rather than 'today'
+
 ## [v1.4.0] - 2019-08-19
 ### Added
 - Campaigns can be filtered to include or exclude archived campaigns

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -39,9 +39,8 @@ export function formatEditTimeDescription (timeVar) {
   const now = new Date()
   // divide difference in timestamps by millisecond conversion
   const daysDifference = Math.floor((now - timeVar) / (1000 * 60 * 60 * 24))
-  const hoursDifference = Math.floor((now - timeVar) / (1000 * 60 * 60))
   if (daysDifference < 1) {
-    return `${hoursDifference} hours ago`
+    return 'In the last 24 hours'
   } else if (daysDifference === 1) {
     return `1 day ago`
   } else return `${daysDifference} days ago`

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -40,7 +40,7 @@ export function formatEditTimeDescription (timeVar) {
   // divide difference in timestamps by millisecond conversion
   const daysDifference = Math.floor((now - timeVar) / (1000 * 60 * 60 * 24))
   if (daysDifference < 1) {
-    return 'today'
+    return 'In the last 24hrs'
   } else if (daysDifference === 1) {
     return `1 day ago`
   } else return `${daysDifference} days ago`

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -40,7 +40,7 @@ export function formatEditTimeDescription (timeVar) {
   // divide difference in timestamps by millisecond conversion
   const daysDifference = Math.floor((now - timeVar) / (1000 * 60 * 60 * 24))
   if (daysDifference < 1) {
-    return 'In the last 24hrs'
+    return 'in the last 24 hours'
   } else if (daysDifference === 1) {
     return `1 day ago`
   } else return `${daysDifference} days ago`

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -39,8 +39,9 @@ export function formatEditTimeDescription (timeVar) {
   const now = new Date()
   // divide difference in timestamps by millisecond conversion
   const daysDifference = Math.floor((now - timeVar) / (1000 * 60 * 60 * 24))
+  const hoursDifference = Math.floor((now - timeVar) / (1000 * 60 * 60))
   if (daysDifference < 1) {
-    return 'in the last 24 hours'
+    return `${hoursDifference} hours ago`
   } else if (daysDifference === 1) {
     return `1 day ago`
   } else return `${daysDifference} days ago`


### PR DESCRIPTION
#418 Currently the time util is calculating 'today' any time within 24hrs of the last edit. This appears to the user as bug when the user is viewing the page on the day following the last edit, but 24hrs has not actually passed since the edit time.

My short solution was to change the text from 'today' to 'In the last 24 hours' 

An alternative approach would be to calculate the time from the user edit time and their time zone to figure out when 'today' ends for them. 
