### PR TITLE
Fix/337 hashtag graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Updated references to hashtag count to fix the hashtag chart
+
 ## [v1.4.0] - 2019-08-19
 ### Added
 - Campaigns can be filtered to include or exclude archived campaigns

--- a/components/charts/CampaignsChart.js
+++ b/components/charts/CampaignsChart.js
@@ -19,16 +19,16 @@ function chartify ({ campaigns, hashtags }) {
     if (hashtag) {
       contributed.push({
         id: campaigns[i].name,
-        edits: hashtag.edit_count
+        edits: hashtag.count
       })
     }
   }
 
   return compose(
     slice(0, 4),
-    map(({ tag, edit_count }) => { return { id: tag, edits: edit_count } }),
+    map(({ tag, count }) => { return { id: tag, edits: count } }),
     reverse,
-    sortBy(prop('edit_count'))
+    sortBy(prop('count'))
   )(hashtags)
 }
 

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -4,8 +4,8 @@ import centerOfMass from '@turf/center-of-mass'
 
 class CampaignMap extends Component {
   render () {
-    if (!this.props.feature.id) {
-      return <span>loading map ...</span>
+    if (!this.props.feature) {
+      return <div />
     }
     const center = centerOfMass(this.props.feature)
 

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -4,8 +4,8 @@ import centerOfMass from '@turf/center-of-mass'
 
 class CampaignMap extends Component {
   render () {
-    if (!this.props.feature) {
-      return <div />
+    if (!this.props.feature.id) {
+      return <span>loading map ...</span>
     }
     const center = centerOfMass(this.props.feature)
 

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -7,7 +7,7 @@ class CampaignMap extends Component {
     if (!this.props.feature.id && this.props.feature.type === 'Feature') {
       return <span>loading map ...</span>
     }
-    
+
     const center = centerOfMass(this.props.feature)
 
     return (


### PR DESCRIPTION
#337 Updates references to hashtag count. It was `edit_count` but live data provided `count`