### PR TITLE
Fixes map controls on campaign pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Country blurb values have a fallback value of '0' if value is not supplied
 - Campaign maps are guaranteed to display AOI due to addition conditional that check for an ID before rendering
+- Campaign map zoom controls are re-enabled
 
 ## [v1.4.0] - 2019-08-19
 ### Added

--- a/styles/App.scss
+++ b/styles/App.scss
@@ -104,7 +104,7 @@ nav {
     li a.active {
       border-bottom: 2px solid rgba(255,255,255,0.7);
       @include media(small-up) {
-        padding-bottom: 0.5rem;
+        padding-bottom: 0.6rem;
       }
     }
     .logo {

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -642,6 +642,7 @@ mark {
 }
 .widget-33.page-actions {
   flex: 1;
+  flex-basis: 100%;
 }
 //HEADER INTERNAL//
 .header--internal {
@@ -1076,7 +1077,6 @@ table {
 .map-lg > .leaflet-container {
   height: 100%;
   background: rgb(222,234,238);
-  z-index: -2;
  }
 
  /* ==========================================================================


### PR DESCRIPTION
Quick fix to enable map controls on campaign pages, which were previously buried in the z-index stack.