### PR TITLE
Feature/loading state

### DIFF
--- a/components/campaigns/CampaignsListing.js
+++ b/components/campaigns/CampaignsListing.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import CampaignCard from './CampaignCard'
+import { LoadingState } from '../common/LoadingState'
 import { range } from 'ramda'
 
 export default ({ records, apiStatus, total, allCount }) => {
@@ -19,7 +20,7 @@ export default ({ records, apiStatus, total, allCount }) => {
     case 'LOADING':
       content = (
         <div>
-          <h3 className='header--medium'>Loading...</h3>
+          <LoadingState />
           <div className='clearfix cards-container widget-container'>
             {range(0, 4).map(idx => <CampaignCard key={`campaign-${idx}`} />)}
           </div>

--- a/components/charts/CalendarHeatmap.js
+++ b/components/charts/CalendarHeatmap.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ResponsiveCalendar } from '@nivo/calendar'
 import getISOYear from 'date-fns/get_iso_year'
+import { LoadingState } from '../common/LoadingState'
 
 class CalendarHeatmap extends React.Component {
   constructor (props) {
@@ -56,6 +57,7 @@ class CalendarHeatmap extends React.Component {
     return (
       <div className='widget' style={{ position: 'relative', height: `${height}px` }} >
         <h4 className='header--small header--with-description-lg'>Edits Over Time</h4>
+        {this.state.loading ? <LoadingState /> : null}
         {
           earliestYear
             ? <ResponsiveCalendar

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -1,30 +1,27 @@
 import React, { Component } from 'react'
 import { Map, TileLayer, GeoJSON } from 'react-leaflet'
 import centerOfMass from '@turf/center-of-mass'
-import { LoadingState } from '../common/LoadingState'
 
 class CampaignMap extends Component {
   render () {
     if (!this.props.feature.id && this.props.feature.type === 'Feature') {
-      return <LoadingState />
+      return <span>loading map ...</span>
     }
 
     const center = centerOfMass(this.props.feature)
 
     return (
-      <React.Fragment>
-        <Map center={center.geometry.coordinates.reverse()} zoom={6} >
-          <TileLayer url='https://api.mapbox.com/styles/v1/devseed/cjqpb3z440t302smfnewsl6vb/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q' />
-          <GeoJSON data={this.props.feature} style={() => {
-            return {
-              color: '#4FCA9C',
-              weight: 1,
-              fillColor: '#4FCA9C',
-              fillOpacity: 0.7
-            }
-          }} />
-        </Map>
-      </React.Fragment>
+      <Map center={center.geometry.coordinates.reverse()} zoom={6} >
+        <TileLayer url='https://api.mapbox.com/styles/v1/devseed/cjqpb3z440t302smfnewsl6vb/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q' />
+        <GeoJSON data={this.props.feature} style={() => {
+          return {
+            color: '#4FCA9C',
+            weight: 1,
+            fillColor: '#4FCA9C',
+            fillOpacity: 0.7
+          }
+        }} />
+      </Map>
     )
   }
 }

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react'
 import { Map, TileLayer, GeoJSON } from 'react-leaflet'
+import { LoadingState } from '../common/LoadingState'
 import centerOfMass from '@turf/center-of-mass'
 
 class CampaignMap extends Component {
   render () {
     if (!this.props.feature.id && this.props.feature.type === 'Feature') {
-      return <span>loading map ...</span>
+      return <LoadingState />
     }
 
     const center = centerOfMass(this.props.feature)

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -1,19 +1,17 @@
 import React, { Component } from 'react'
 import { Map, TileLayer, GeoJSON } from 'react-leaflet'
 import centerOfMass from '@turf/center-of-mass'
-import { showGlobalLoading, hideGlobalLoading, GlobalLoading } from '../common/LoadingState'
+import { LoadingState } from '../common/LoadingState'
 
 class CampaignMap extends Component {
   render () {
-    if (this.props.feature.id) {
-      // return <span>loading map ...</span>
-      showGlobalLoading(20)
+    if (!this.props.feature.id && this.props.feature.type === 'Feature') {
+      return <LoadingState />
     }
     const center = centerOfMass(this.props.feature)
 
     return (
       <React.Fragment>
-        <GlobalLoading />
         <Map center={center.geometry.coordinates.reverse()} zoom={6} >
           <TileLayer url='https://api.mapbox.com/styles/v1/devseed/cjqpb3z440t302smfnewsl6vb/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q' />
           <GeoJSON data={this.props.feature} style={() => {

--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -1,26 +1,31 @@
 import React, { Component } from 'react'
 import { Map, TileLayer, GeoJSON } from 'react-leaflet'
 import centerOfMass from '@turf/center-of-mass'
+import { showGlobalLoading, hideGlobalLoading, GlobalLoading } from '../common/LoadingState'
 
 class CampaignMap extends Component {
   render () {
-    if (!this.props.feature.id) {
-      return <span>loading map ...</span>
+    if (this.props.feature.id) {
+      // return <span>loading map ...</span>
+      showGlobalLoading(20)
     }
     const center = centerOfMass(this.props.feature)
 
     return (
-      <Map center={center.geometry.coordinates.reverse()} zoom={6} >
-        <TileLayer url='https://api.mapbox.com/styles/v1/devseed/cjqpb3z440t302smfnewsl6vb/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q' />
-        <GeoJSON data={this.props.feature} style={() => {
-          return {
-            color: '#4FCA9C',
-            weight: 1,
-            fillColor: '#4FCA9C',
-            fillOpacity: 0.7
-          }
-        }} />
-      </Map>
+      <React.Fragment>
+        <GlobalLoading />
+        <Map center={center.geometry.coordinates.reverse()} zoom={6} >
+          <TileLayer url='https://api.mapbox.com/styles/v1/devseed/cjqpb3z440t302smfnewsl6vb/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoiZGV2c2VlZCIsImEiOiJnUi1mbkVvIn0.018aLhX0Mb0tdtaT2QNe2Q' />
+          <GeoJSON data={this.props.feature} style={() => {
+            return {
+              color: '#4FCA9C',
+              weight: 1,
+              fillColor: '#4FCA9C',
+              fillOpacity: 0.7
+            }
+          }} />
+        </Map>
+      </React.Fragment>
     )
   }
 }

--- a/components/common/LoadingState.js
+++ b/components/common/LoadingState.js
@@ -1,0 +1,170 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+import { CSSTransition } from 'react-transition-group'
+
+// Minimum time the loading is visible.
+const MIN_TIME = 512
+// Since we have a minimum display time we use a timeout to hide it if
+// when the hide method is called the time isn't over yet. However, if in
+// the mean time the loading is shown again we need to clear the timeout.
+var hideTimeout = null
+
+// Once the component is mounted we store it to be able to access it from
+// the outside.
+var theGlobalLoading = null
+
+// Store the amount of global loading calls so we can keep it visible until
+// all were hidden.
+let theGlobalLoadingCount = 0
+
+export class GlobalLoading extends React.Component {
+  constructor (props) {
+    super(props)
+    this.componentAddedBodyClass = false
+
+    this.state = {
+      showTimestamp: 0,
+      revealed: false
+    }
+  }
+
+  toggleBodyClass (revealed) {
+    let bd = document.getElementsByTagName('body')[0]
+    if (revealed) {
+      this.componentAddedBodyClass = true
+      bd.classList.add('unscrollable-y')
+    } else if (this.componentAddedBodyClass) {
+      // Only act if the class was added by this component.
+      this.componentAddedBodyClass = false
+      bd.classList.remove('unscrollable-y')
+    }
+  }
+
+  componentDidMount () {
+    // if (theGlobalLoading !== null) {
+    //   throw new Error('<GlobalLoading /> component was already mounted. Only 1 is allowed.')
+    // }
+    theGlobalLoading = this
+    this.toggleBodyClass(this.state.revealed)
+  }
+
+  componentDidUpdate () {
+    this.toggleBodyClass(this.state.revealed)
+  }
+
+  componentWillUnmount () {
+    this.toggleBodyClass(false)
+    theGlobalLoading = null
+  }
+
+  render () {
+    return createPortal((
+      <CSSTransition
+        in={this.state.revealed}
+        unmountOnExit
+        appear
+        classNames='loading-pane'
+        timeout={{ enter: 300, exit: 300 }}>
+
+        <div className='loading-pane'>
+          <div className='spinner'>
+            <div className='spinner__bounce' />
+            <div className='spinner__bounce' />
+            <div className='spinner__bounce' />
+          </div>
+        </div>
+
+      </CSSTransition>
+    ), document.body)
+  }
+}
+
+/**
+ * Show a global loading.
+ * The loading has a minimum visible time defined by the MIN_TIME constant.
+ * This will prevent flickers in the interface when the action is very fast.
+ * @param  {Number} count Define how many loadings to show. This will not
+ *                        show multiple loadings on the page but will increment
+ *                        a counter. This is helpful when there are many actions
+ *                        that require a loading.
+ *                        The global loading will only be dismissed once all
+ *                        counters shown are hidden.
+ *                        Each function call will increment the counter.
+ *                        Default 1
+ * @example
+ * showGlobalLoading()
+ * // Counter set to 1
+ * showGlobalLoading(3)
+ * // Counter set to 4
+ * hideGlobalLoading()
+ * // Counter is now 3
+ * hideGlobalLoading(3)
+ * // Counter is now 0 and the loading is dismissed.
+ */
+export function showGlobalLoading (count = 1) {
+  if (theGlobalLoading === null) {
+    throw new Error('<GlobalLoading /> component not mounted')
+  }
+  if (hideTimeout) {
+    clearTimeout(hideTimeout)
+  }
+
+  theGlobalLoadingCount += count
+
+  theGlobalLoading.setState({
+    showTimestamp: Date.now(),
+    revealed: true
+  })
+}
+
+/**
+ * Hides a global loading
+ * @param  {Number} count Define how many loadings to hide. Using 0 or any
+ *                        negative number will immediately dismiss the loading
+ *                        without waiting for the minimum display time.
+ *                        Default 1
+ * @param {function} cb   Callback called after the loading is hidden.
+ *
+ * @example
+ * showGlobalLoading()
+ * // Counter set to 1
+ * showGlobalLoading(3)
+ * // Counter set to 4
+ * hideGlobalLoading()
+ * // Counter is now 3
+ * hideGlobalLoading(3)
+ * // Counter is now 0 and the loading is dismissed.
+ */
+export function hideGlobalLoading (count = 1, cb = () => {}) {
+  if (theGlobalLoading === null) {
+    throw new Error('<GlobalLoading /> component not mounted')
+  }
+
+  if (typeof count === 'function') {
+    cb = count
+    count = 1
+  }
+
+  const hide = () => { theGlobalLoading.setState({ revealed: false }); cb() }
+
+  // Using 0 or negative numbers results in the loading being
+  // immediately dismissed.
+  if (count < 1) {
+    theGlobalLoadingCount = 0
+    return hide()
+  }
+
+  // Decrement counter by given amount without going below 0.
+  theGlobalLoadingCount -= count
+  if (theGlobalLoadingCount < 0) theGlobalLoadingCount = 0
+
+  let time = theGlobalLoading.state.showTimestamp
+  let diff = Date.now() - time
+  if (diff >= MIN_TIME) {
+    if (theGlobalLoadingCount === 0) return hide()
+  } else {
+    hideTimeout = setTimeout(() => {
+      if (theGlobalLoadingCount === 0) return hide()
+    }, MIN_TIME - diff)
+  }
+}

--- a/components/common/LoadingState.js
+++ b/components/common/LoadingState.js
@@ -2,70 +2,11 @@ import React from 'react'
 import { createPortal } from 'react-dom'
 import { CSSTransition } from 'react-transition-group'
 
-// Minimum time the loading is visible.
-const MIN_TIME = 512
-// Since we have a minimum display time we use a timeout to hide it if
-// when the hide method is called the time isn't over yet. However, if in
-// the mean time the loading is shown again we need to clear the timeout.
-var hideTimeout = null
-
-// Once the component is mounted we store it to be able to access it from
-// the outside.
-var theGlobalLoading = null
-
-// Store the amount of global loading calls so we can keep it visible until
-// all were hidden.
-let theGlobalLoadingCount = 0
-
 export class GlobalLoading extends React.Component {
-  constructor (props) {
-    super(props)
-    this.componentAddedBodyClass = false
-
-    this.state = {
-      showTimestamp: 0,
-      revealed: false
-    }
-  }
-
-  toggleBodyClass (revealed) {
-    let bd = document.getElementsByTagName('body')[0]
-    if (revealed) {
-      this.componentAddedBodyClass = true
-      bd.classList.add('unscrollable-y')
-    } else if (this.componentAddedBodyClass) {
-      // Only act if the class was added by this component.
-      this.componentAddedBodyClass = false
-      bd.classList.remove('unscrollable-y')
-    }
-  }
-
-  componentDidMount () {
-    // if (theGlobalLoading !== null) {
-    //   throw new Error('<GlobalLoading /> component was already mounted. Only 1 is allowed.')
-    // }
-    theGlobalLoading = this
-    this.toggleBodyClass(this.state.revealed)
-  }
-
-  componentDidUpdate () {
-    this.toggleBodyClass(this.state.revealed)
-  }
-
-  componentWillUnmount () {
-    this.toggleBodyClass(false)
-    theGlobalLoading = null
-  }
 
   render () {
     return createPortal((
-      <CSSTransition
-        in={this.state.revealed}
-        unmountOnExit
-        appear
-        classNames='loading-pane'
-        timeout={{ enter: 300, exit: 300 }}>
-
+      <div className='loading-container'>
         <div className='loading-pane'>
           <div className='spinner'>
             <div className='spinner__bounce' />
@@ -73,98 +14,7 @@ export class GlobalLoading extends React.Component {
             <div className='spinner__bounce' />
           </div>
         </div>
-
-      </CSSTransition>
+      </div>
     ), document.body)
-  }
-}
-
-/**
- * Show a global loading.
- * The loading has a minimum visible time defined by the MIN_TIME constant.
- * This will prevent flickers in the interface when the action is very fast.
- * @param  {Number} count Define how many loadings to show. This will not
- *                        show multiple loadings on the page but will increment
- *                        a counter. This is helpful when there are many actions
- *                        that require a loading.
- *                        The global loading will only be dismissed once all
- *                        counters shown are hidden.
- *                        Each function call will increment the counter.
- *                        Default 1
- * @example
- * showGlobalLoading()
- * // Counter set to 1
- * showGlobalLoading(3)
- * // Counter set to 4
- * hideGlobalLoading()
- * // Counter is now 3
- * hideGlobalLoading(3)
- * // Counter is now 0 and the loading is dismissed.
- */
-export function showGlobalLoading (count = 1) {
-  if (theGlobalLoading === null) {
-    throw new Error('<GlobalLoading /> component not mounted')
-  }
-  if (hideTimeout) {
-    clearTimeout(hideTimeout)
-  }
-
-  theGlobalLoadingCount += count
-
-  theGlobalLoading.setState({
-    showTimestamp: Date.now(),
-    revealed: true
-  })
-}
-
-/**
- * Hides a global loading
- * @param  {Number} count Define how many loadings to hide. Using 0 or any
- *                        negative number will immediately dismiss the loading
- *                        without waiting for the minimum display time.
- *                        Default 1
- * @param {function} cb   Callback called after the loading is hidden.
- *
- * @example
- * showGlobalLoading()
- * // Counter set to 1
- * showGlobalLoading(3)
- * // Counter set to 4
- * hideGlobalLoading()
- * // Counter is now 3
- * hideGlobalLoading(3)
- * // Counter is now 0 and the loading is dismissed.
- */
-export function hideGlobalLoading (count = 1, cb = () => {}) {
-  if (theGlobalLoading === null) {
-    throw new Error('<GlobalLoading /> component not mounted')
-  }
-
-  if (typeof count === 'function') {
-    cb = count
-    count = 1
-  }
-
-  const hide = () => { theGlobalLoading.setState({ revealed: false }); cb() }
-
-  // Using 0 or negative numbers results in the loading being
-  // immediately dismissed.
-  if (count < 1) {
-    theGlobalLoadingCount = 0
-    return hide()
-  }
-
-  // Decrement counter by given amount without going below 0.
-  theGlobalLoadingCount -= count
-  if (theGlobalLoadingCount < 0) theGlobalLoadingCount = 0
-
-  let time = theGlobalLoading.state.showTimestamp
-  let diff = Date.now() - time
-  if (diff >= MIN_TIME) {
-    if (theGlobalLoadingCount === 0) return hide()
-  } else {
-    hideTimeout = setTimeout(() => {
-      if (theGlobalLoadingCount === 0) return hide()
-    }, MIN_TIME - diff)
   }
 }

--- a/components/common/LoadingState.js
+++ b/components/common/LoadingState.js
@@ -1,11 +1,8 @@
 import React from 'react'
-import { createPortal } from 'react-dom'
-import { CSSTransition } from 'react-transition-group'
 
-export class GlobalLoading extends React.Component {
-
+export class LoadingState extends React.Component {
   render () {
-    return createPortal((
+    return (
       <div className='loading-container'>
         <div className='loading-pane'>
           <div className='spinner'>
@@ -15,6 +12,6 @@ export class GlobalLoading extends React.Component {
           </div>
         </div>
       </div>
-    ), document.body)
+    )
   }
 }

--- a/components/countries/AllCountriesTable.js
+++ b/components/countries/AllCountriesTable.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from '../Link'
 const { formatDecimal } = require('../../lib/utils/format')
+import { LoadingState } from '../common/LoadingState'
 
 export default function CountriesTable ({ apiStatus, countries }) {
   let content = <div />
@@ -30,7 +31,7 @@ export default function CountriesTable ({ apiStatus, countries }) {
       )
       break
     case 'LOADING':
-      content = <div>Loading...</div>
+      content = <LoadingState />
       break
 
     case 'ERROR':

--- a/components/countries/AllCountriesTable.js
+++ b/components/countries/AllCountriesTable.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Link from '../Link'
-const { formatDecimal } = require('../../lib/utils/format')
 import { LoadingState } from '../common/LoadingState'
+const { formatDecimal } = require('../../lib/utils/format')
 
 export default function CountriesTable ({ apiStatus, countries }) {
   let content = <div />

--- a/components/users/AllUsersTable.js
+++ b/components/users/AllUsersTable.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import Link from '../Link'
 import { formatDecimal, formatEditTimeDescription } from '../../lib/utils/format'
+import { LoadingState } from '../common/LoadingState'
 import { parse } from 'date-fns'
 
 const UsersTable = ({ apiStatus, users }) => {
@@ -36,7 +37,7 @@ const UsersTable = ({ apiStatus, users }) => {
       )
       break
     case 'LOADING':
-      content = <div>Loading...</div>
+      content = <LoadingState />
       break
 
     case 'ERROR':

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "react-markdown": "^3.1.1",
     "react-responsive-carousel": "^3.1.43",
     "react-select": "^1.2.1",
-    "react-transition-group": "^2.5.0",
+    "react-transition-group": "^4.3.0",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "simple-oauth2": "^2.2.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,6 +23,7 @@ import '../styles/Dashboard.scss'
 import '../styles/Campaigns.scss'
 import '../styles/Users.scss'
 import '../styles/Badges.scss'
+import '../styles/LoadingState.scss'
 
 /* CSS */
 import 'react-select/dist/react-select.css'

--- a/pages/admin/badges-add.js
+++ b/pages/admin/badges-add.js
@@ -7,6 +7,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
+import { LoadingState } from '../../components/common/LoadingState'
 import Link from '../../components/Link'
 import imageList from '../../lib/utils/loadImages'
 import { Carousel } from 'react-responsive-carousel'
@@ -71,7 +72,10 @@ export class AdminBadgesAdd extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/badges-edit.js
+++ b/pages/admin/badges-edit.js
@@ -7,6 +7,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
+import { LoadingState } from '../../components/common/LoadingState'
 import Link from '../../components/Link'
 import imageList from '../../lib/utils/loadImages'
 import { Carousel } from 'react-responsive-carousel'
@@ -90,7 +91,10 @@ export class AdminBadgesEdit extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/badges.js
+++ b/pages/admin/badges.js
@@ -6,6 +6,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
+import { LoadingState } from '../../components/common/LoadingState'
 import Link from '../../components/Link'
 
 export class AdminBadges extends Component {
@@ -68,7 +69,10 @@ export class AdminBadges extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/edit-user.js
+++ b/pages/admin/edit-user.js
@@ -8,6 +8,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminUserEdit extends Component {
   constructor () {
@@ -63,7 +64,10 @@ export class AdminUserEdit extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/index.js
+++ b/pages/admin/index.js
@@ -7,6 +7,7 @@ import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import AdminSectionList from '../../components/admin/AdminSectionList'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class Admin extends Component {
   constructor () {
@@ -32,7 +33,10 @@ export class Admin extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/tasking-managers-add.js
+++ b/pages/admin/tasking-managers-add.js
@@ -7,6 +7,7 @@ import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import QueryParameters from '../../components/QueryParameters'
+import { LoadingState } from '../../components/common/LoadingState'
 import Select from 'react-select'
 import Link from '../../components/Link'
 
@@ -63,7 +64,10 @@ export class AdminTaskersAdd extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/tasking-managers-edit.js
+++ b/pages/admin/tasking-managers-edit.js
@@ -7,6 +7,7 @@ import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import QueryParameters from '../../components/QueryParameters'
+import { LoadingState } from '../../components/common/LoadingState'
 import Select from 'react-select'
 import Link from '../../components/Link'
 
@@ -83,7 +84,10 @@ export class AdminTaskersEdit extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/teams-add.js
+++ b/pages/admin/teams-add.js
@@ -7,6 +7,7 @@ import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import Link from '../../components/Link'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminTeamsAdd extends Component {
   constructor () {
@@ -55,7 +56,10 @@ export class AdminTeamsAdd extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/teams-edit.js
+++ b/pages/admin/teams-edit.js
@@ -9,6 +9,7 @@ import AdminHeader from '../../components/admin/AdminHeader'
 import AdminCampaignsSearch from '../../components/admin/AdminCampaignsSearch'
 import AdminUsersSearch from '../../components/admin/AdminUsersSearch'
 import Link from '../../components/Link'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminTeamsEdit extends Component {
   constructor () {
@@ -148,7 +149,10 @@ export class AdminTeamsEdit extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/teams.js
+++ b/pages/admin/teams.js
@@ -7,6 +7,7 @@ import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import Link from '../../components/Link'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminTeams extends Component {
   constructor () {
@@ -70,7 +71,10 @@ export class AdminTeams extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/users-exclusion.js
+++ b/pages/admin/users-exclusion.js
@@ -8,6 +8,7 @@ import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
 import AdminUsersSearch from '../../components/admin/AdminUsersSearch'
 import Link from '../../components/Link'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminExclusionList extends Component {
   constructor () {
@@ -69,7 +70,10 @@ export class AdminExclusionList extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/admin/users.js
+++ b/pages/admin/users.js
@@ -7,6 +7,7 @@ import { actions } from '../../lib/store'
 import { isAdmin } from '../../lib/utils/roles'
 import NotLoggedIn from '../../components/NotLoggedIn'
 import AdminHeader from '../../components/admin/AdminHeader'
+import { LoadingState } from '../../components/common/LoadingState'
 
 export class AdminUsers extends Component {
   constructor () {
@@ -75,7 +76,10 @@ export class AdminUsers extends Component {
 
     if (this.state.loading) {
       return (
-        <div><AdminHeader /></div>
+        <div>
+          <AdminHeader />
+          <LoadingState />
+        </div>
       )
     }
 

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -15,6 +15,7 @@ import DashboardAssignments from '../components/dashboard/DashboardAssignments'
 import DashboardHeader from '../components/dashboard/DashboardHeader'
 import DashboardSidebar from '../components/dashboard/DashboardSidebar'
 import DashboardBlurb from '../components/dashboard/DashboardBlurb'
+import { LoadingState } from '../components/common/LoadingState'
 import CampaignsChart from '../components/charts/CampaignsChart'
 import EditBreakdownChart from '../components/charts/EditBreakdownChart'
 import { formatDecimal } from '../lib/utils/format'
@@ -57,7 +58,7 @@ class Dashboard extends Component {
 
   render () {
     if (this.state.loading) {
-      return <div />
+      return <LoadingState />
     }
     const { authenticatedUser } = this.props
     const { loggedIn, account } = authenticatedUser

--- a/styles/LoadingState.scss
+++ b/styles/LoadingState.scss
@@ -5,26 +5,20 @@
    Loading
    ========================================================================== */
   .loading-container {
-    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
    
    .loading-pane {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 9997;
     cursor: not-allowed;
+    padding: 3rem;
   
     .spinner {
-      position: absolute;
-      z-index: 2;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+      justify-content: center;
+      align-items: center;
     }
   }
   
@@ -34,7 +28,7 @@
   
   .spinner {
     font-size: 0;
-    border-radius: 100vh;
+    border-radius: 50px;
     background: rgba($base-color, 0.8);
     padding: 1.5rem 1rem 1rem 1rem;
   }
@@ -43,7 +37,7 @@
     width: 1rem;
     height: 1rem;
     background: #fff;
-    border-radius: 100vh;
+    border-radius: 50px;
     display: inline-block;
     margin: 0 (1rem / 4);
     animation: spinner-bouncedelay 1.4s infinite ease-in-out both;

--- a/styles/LoadingState.scss
+++ b/styles/LoadingState.scss
@@ -1,0 +1,101 @@
+@import 'settings/variables.scss';
+@import 'settings/mixins.scss';
+
+/* ==========================================================================
+   Loading
+   ========================================================================== */
+
+   .loading-pane {
+    @extend .antialiased;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 9997;
+    cursor: not-allowed;
+  
+    .spinner {
+      position: absolute;
+      z-index: 2;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+  }
+  
+  
+  /* Spinner
+     ========================================================================== */
+  
+  .spinner {
+    font-size: 0;
+    border-radius: $full-border-radius;
+    background: rgba($base-color, 0.8);
+    padding: $global-spacing / 2;
+  }
+  
+  .spinner__bounce {
+    width: 1rem;
+    height: 1rem;
+    background: #fff;
+    border-radius: $full-border-radius;
+    display: inline-block;
+    margin: 0 ($global-spacing / 4);
+    animation: spinner-bouncedelay 1.4s infinite ease-in-out both;
+  
+    &:first-child {
+      margin-left: 0;
+    }
+  
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+  
+  .spinner__bounce:nth-child(1) {
+    animation-delay: -0.32s;
+  }
+  
+  .spinner__bounce:nth-child(2) {
+    animation-delay: -0.16s;
+  }
+  
+  @keyframes spinner-bouncedelay {
+    0%,
+    80%,
+    100% { 
+      transform: scale(0);
+    }
+  
+    40% { 
+      transform: scale(1.0);
+    }
+  }
+  
+  
+  /* Loading pane react animation
+     ========================================================================== */
+  
+  .loading-pane-enter {
+    transform: translate3d(0, 0, 0);
+    transition: opacity 0.32s ease 0s, visibility 0.32s linear 0s;
+    opacity: 0;
+    visibility: hidden;
+  
+    &.loading-pane-enter-active {
+      opacity: 1;
+      visibility: visible;
+    }
+  }
+  
+  .loading-pane-exit {
+    transition: opacity 0.32s ease 0s, visibility 0.32s linear 0s;
+    opacity: 1;
+    visibility: visible;
+  
+    &.loading-pane-exit-active {
+      opacity: 0;
+      visibility: hidden;
+    }
+  }

--- a/styles/LoadingState.scss
+++ b/styles/LoadingState.scss
@@ -4,9 +4,13 @@
 /* ==========================================================================
    Loading
    ========================================================================== */
-
+  .loading-container {
+    position: relative;
+  }
+   
    .loading-pane {
-    @extend .antialiased;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     position: fixed;
     top: 0;
     left: 0;
@@ -30,18 +34,18 @@
   
   .spinner {
     font-size: 0;
-    border-radius: $full-border-radius;
+    border-radius: 100vh;
     background: rgba($base-color, 0.8);
-    padding: $global-spacing / 2;
+    padding: 1.5rem 1rem 1rem 1rem;
   }
   
   .spinner__bounce {
     width: 1rem;
     height: 1rem;
     background: #fff;
-    border-radius: $full-border-radius;
+    border-radius: 100vh;
     display: inline-block;
-    margin: 0 ($global-spacing / 4);
+    margin: 0 (1rem / 4);
     animation: spinner-bouncedelay 1.4s infinite ease-in-out both;
   
     &:first-child {


### PR DESCRIPTION
**Description:**
Adds a component loading state that fills the width of its parent component.

**Rationale:**
This is useful for conveying to the user that a feature exists and is forthcoming. 
Currently there were a few empty divs that were unable to communicate this, there were some spans that showed `loading` in which case, this is more beautification than anything.

**Future Work:**
- There are a number of components that could use this that are not included in this pr. I have only changed out loading states where existing logic exists with the exception of the admin components like [this](https://github.com/developmentseed/scoreboard/blob/b1a628c93f1cf4452bcfc1b58f4f635170de17d0/pages/admin/teams-edit.js#L149) one. It would be quite easy to add in a loading state beneath this component but I need advice on how to test that it is working as expected. I don't think my user permissions allow access to those pages. I may be wrong.

- The site could do with a global loading state. This PR does not offer this. I spent some time looking through the codebase to find a place to do implement it. @LanesGood @kamicut mentioned the complexities of addressing this before. Now that I am more familiar with the codebase I would be up for another discussion for how this might be possible. Implementation of the loader would be a simple as adding a global wrapper around the component, the location of this component is tbd.

<img width="1400" alt="users" src="https://user-images.githubusercontent.com/20410256/65918190-100f6a00-e3a7-11e9-83c3-3bafedfc950f.png">

