### PR TITLE
Remove redundant tooltips from campaign tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed source environment URL join from Edit Profile link in menu
 - Replace `edit_sum` on User pages with the updated `edit_count` from OSMesa
 - Fixes bug in tables when defaults for statistics are not provided by the API
-
+- Remove redundant tooltips from campaign tables
 ## [v1.6.0] - 2019-10-28
 ### Changed
 - Move all table header labels to common json file with descriptions.

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -28,12 +28,8 @@ const tableSchema = {
   ],
   'displaysTooltip': [
     'name',
-    'roads',
     'buildings',
     'poi',
-    'railways',
-    'coastlines',
-    'waterways',
     'changesets',
     'edits'
   ]
@@ -60,7 +56,10 @@ export default function CampaignTable (props) {
   return (
     <div className='widget clearfix table-wrapper'>
       <Table idMap={idMap} tableSchema={tableSchema} data={campaignTopStats} initialSortColumn='edit_count' />
-      <CSVExport filename={props.name} data={campaignTopStats} />
+      <div>
+        <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
+        <CSVExport filename={props.name} data={campaignTopStats} />
+      </div>
     </div>
   )
 }

--- a/styles/Campaigns.scss
+++ b/styles/Campaigns.scss
@@ -239,9 +239,17 @@ fieldset {
 .table-wrapper {
   overflow: auto;
   display: flex;
-  flex-flow: column nowrap;
+  flex-flow: row wrap;
   align-items: flex-end;
+
+  .table {
+    flex: 1;
+  }
+
   > *:last-child {
     margin-top: 2rem;
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
   }
 }


### PR DESCRIPTION
Removes redundant tooltips from campaign tables, and add note on Km of roads, railways, coastlines and waterways representing added + modified.

![image](https://user-images.githubusercontent.com/12634024/69740746-e1dcab00-1107-11ea-87b8-04d3e690869c.png)
