### PR TITLE
Fix/449 empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix pagination bug for users table
 
 ## [v1.7.0] - 2019-11-28
 ### Added

--- a/pages/users.js
+++ b/pages/users.js
@@ -103,7 +103,7 @@ export class Users extends Component {
               <Pagination
                 activePage={page}
                 itemsCountPerPage={25}
-                totalItemsCount={total}
+                totalItemsCount={subTotal}
                 pageRangeDisplayed={5}
                 onChange={this.handlePageChange}
               />


### PR DESCRIPTION
This fixes #449 for the users table. @LanesGood is there another table that has pagination that has this bug? The countries table doesn't have pagination, and the campaigns pagination doesn't have this problem. 