### PR TITLE
Update table icons and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Table header link hover color; allows user to more easily distinguish hovered column
+- Shortened "POI" description to save space
+
+### Fixed
+- Fixed path issue for rendering table icons
+
+
 ## [v1.7.1] - 2019-12-02
 ### Fixed
 - Fix pagination bug for users table

--- a/components/common/Table.js
+++ b/components/common/Table.js
@@ -125,7 +125,11 @@ export default function Table (props) {
           {
             headers.map(column =>
               sortable ? (
-                <th key={column.id} {...column.getHeaderProps(column.getSortByToggleProps())}>
+                <th
+                  key={column.id}
+                  {...column.getHeaderProps(column.getSortByToggleProps())}
+                  title={column.Header.props ? `Sort by ${column.Header.props.children}` : `Sort by ${column.Header}`}
+                >
                   <a className={column.isSorted ? (column.isSortedDesc ? 'sort-desc' : 'sort-asc') : 'sort-none'}>
                     {column.Header}
                   </a>

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -41,8 +41,8 @@
     },
     {
         "id":"poi",
-        "name":"Points of Interest",
-        "description":"Health centers, schools, town halls, places of worship, etc."
+        "name":"POI",
+        "description":"Points of Interest: Health centers, schools, town halls, places of worship, etc."
     },
     {
         "id":"railways",

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -42,7 +42,7 @@
     {
         "id":"poi",
         "name":"POI",
-        "description":"Points of Interest: Health centers, schools, town halls, places of worship, etc."
+        "description":"Points of Interest: Health centers, schools, town halls, places of worship, amenities, shops, craft, offices, leisure, aeroways, etc."
     },
     {
         "id":"railways",

--- a/styles/Campaigns.scss
+++ b/styles/Campaigns.scss
@@ -251,5 +251,9 @@ fieldset {
     display: flex;
     width: 100%;
     justify-content: space-between;
+    align-items: center;
+    .button {
+      flex-shrink: 0;
+    }
   }
 }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1026,6 +1026,7 @@ table {
     padding: 0.8rem 0;
     vertical-align: middle;
     position: relative;
+    line-height: 1.25;
     @include media(small-up) {
       &:first-child {
         padding-left: .8em;
@@ -1040,28 +1041,52 @@ table {
       justify-content: flex-start;
       align-items: center;
       &:after {
-        content: url($appUrlFinal + 'static/sort-none.svg');
-        margin-top: 0.25rem;
+        mask: url($appUrlFinal + 'static/sort-none.svg');
+        -webkit-mask: url($appUrlFinal + 'static/sort-none.svg');
+        mask-size: cover;
+        -webkit-mask-size: cover;
+        background: $base-font-color;
+        display: inline-block;
+        content: '';
+        height: 16px;
+        width: 16px;
+        transition: .3s all;
       }
-      &:hover {
+      &:hover,
+      &:focus {
         color: $base-color;
+        &:after,
+        .table-tooltip:after {
+          background: $base-color;
+        }
       }
     }
     a.sort-asc {
       &:after {
-        content: url($appUrlFinal + 'static/sort-asc.svg');
+        mask: url($appUrlFinal + 'static/sort-asc.svg');
+        -webkit-mask: url($appUrlFinal + 'static/sort-asc.svg');
       }
     }
     a.sort-desc {
       &:after {
-        content: url($appUrlFinal + 'static/sort-desc.svg');
+        mask: url($appUrlFinal + 'static/sort-desc.svg');
+        -webkit-mask: url($appUrlFinal + 'static/sort-desc.svg');
       }
     }
     .table-tooltip {
       &:after {
-        content: url($appUrlFinal + 'static/circle-information.svg');
+        mask: url($appUrlFinal + 'static/circle-information.svg');
+        -webkit-mask: url($appUrlFinal + 'static/circle-information.svg');
+        mask-size: cover;
+        -webkit-mask-size: cover;
         margin-top: -.5rem;
         opacity: 0.5;
+        background: $base-font-color;
+        display: inline-block;
+        content: '';
+        height: 12px;
+        width: 12px;
+        transition: .3s all;
       }
     }
   }

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1037,7 +1037,7 @@ table {
     }
     a[class^='sort'] {
       &:after {
-        content: url($appUrlFinal + '../static/sort-none.svg');
+        content: url($appUrlFinal + 'static/sort-none.svg');
         vertical-align: middle;
         position: absolute;
         top: 50%;
@@ -1048,17 +1048,17 @@ table {
     }
     a.sort-asc {
       &:after {
-        content: url($appUrlFinal + '../static/sort-asc.svg');
+        content: url($appUrlFinal + 'static/sort-asc.svg');
       }
     }
     a.sort-desc {
       &:after {
-        content: url($appUrlFinal + '../static/sort-desc.svg');
+        content: url($appUrlFinal + 'static/sort-desc.svg');
       }
     }
     .table-tooltip {
       &:after {
-        content: url($appUrlFinal + '../static/circle-information.svg');
+        content: url($appUrlFinal + 'static/circle-information.svg');
         vertical-align: middle;
         position: absolute;
         margin-top: -.5rem;

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1023,7 +1023,7 @@ table {
     font-family: $tertiary-font-family;
     text-transform: uppercase;
     color: $base-header-color;
-    padding: 0.8rem 0.2rem;
+    padding: 0.8rem 0;
     vertical-align: middle;
     position: relative;
     @include media(small-up) {
@@ -1042,6 +1042,9 @@ table {
       &:after {
         content: url($appUrlFinal + 'static/sort-none.svg');
         margin-top: 0.25rem;
+      }
+      &:hover {
+        color: $base-color;
       }
     }
     a.sort-asc {

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1023,8 +1023,7 @@ table {
     font-family: $tertiary-font-family;
     text-transform: uppercase;
     color: $base-header-color;
-    padding-top: .8em;
-    padding-bottom: .8em;
+    padding: 0.8rem 0.2rem;
     vertical-align: middle;
     position: relative;
     @include media(small-up) {
@@ -1036,14 +1035,13 @@ table {
       }
     }
     a[class^='sort'] {
+      display: flex;
+      flex-flow: row nowrap;
+      justify-content: flex-start;
+      align-items: center;
       &:after {
         content: url($appUrlFinal + 'static/sort-none.svg');
-        vertical-align: middle;
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        margin-left: -0.3rem;
-        margin-top: 0.2rem;
+        margin-top: 0.25rem;
       }
     }
     a.sort-asc {
@@ -1059,8 +1057,6 @@ table {
     .table-tooltip {
       &:after {
         content: url($appUrlFinal + 'static/circle-information.svg');
-        vertical-align: middle;
-        position: absolute;
         margin-top: -.5rem;
         opacity: 0.5;
       }
@@ -1256,9 +1252,9 @@ table {
 }
 
 span[data-tip] {
-  position: relative;
-  padding-right: 1rem;
-  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 }
 
 .__react_component_tooltip {

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1023,10 +1023,11 @@ table {
     font-family: $tertiary-font-family;
     text-transform: uppercase;
     color: $base-header-color;
-    padding: 0.8rem 0;
+    padding: 0.8rem 0.15rem;
     vertical-align: middle;
     position: relative;
     line-height: 1.25;
+    white-space: nowrap;
     @include media(small-up) {
       &:first-child {
         padding-left: .8em;
@@ -1108,14 +1109,8 @@ table {
     }
   }
   td {
-    padding: .9em 4em .8em 0;
+    padding: 0.8rem 0.15rem;
     margin: 0;
-    @include media(xlarge-up) {
-      padding-right: 4em;
-    }
-    @include media(medium-down) {
-      padding-right: 1em;
-    }
   }
 }
 
@@ -1289,4 +1284,7 @@ span[data-tip] {
   font-weight: initial;
   font-family: $heading-font-regular;
   text-transform: none;
+  max-width: 18rem;
+  line-height: 1.4;
+  white-space: normal;
 }


### PR DESCRIPTION
Closes #454 and fixes path issue for rendering table icons. Also added:
- table header link hover color; allows user to more easily distinguish hovered column
- shortened "POI" description to save space

![image](https://user-images.githubusercontent.com/12634024/69994838-c6650c00-151c-11ea-9adc-5303bd904dde.png)
