### PR TITLE
Catch undefined headers for sort column title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Catch undefined headers for sort column title
+
 ## [v1.7.2] - 2019-12-03
 ### Changed
 - Table header link hover color; allows user to more easily distinguish hovered column

--- a/components/common/Table.js
+++ b/components/common/Table.js
@@ -128,7 +128,7 @@ export default function Table (props) {
                 <th
                   key={column.id}
                   {...column.getHeaderProps(column.getSortByToggleProps())}
-                  title={column.Header.props ? `Sort by ${column.Header.props.children}` : `Sort by ${column.Header}`}
+                  title={!column.Header ? 'Sort column' : (column.Header.props ? `Sort by ${column.Header.props.children}` : `Sort by ${column.Header}`)}
                 >
                   <a className={column.isSorted ? (column.isSortedDesc ? 'sort-desc' : 'sort-asc') : 'sort-none'}>
                     {column.Header}


### PR DESCRIPTION
Catch undefined headers for sort column `title` property. Fixes #462 