### PR TITLE
Add total row to Campaign Table CSV export

### DIFF
--- a/components/CSVExport.js
+++ b/components/CSVExport.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { CSVLink } from 'react-csv'
+import { formatDecimal } from '../lib/utils/format'
 
 export default function CSVExport ({ filename, data }) {
+  const isUser = data[0].campaignCount > 0
+  let totalData = data
   let headers = [
     { label: 'Name', key: 'name' },
     { label: 'Roads (Km) Added', key: 'km_roads_add' },
@@ -19,17 +22,36 @@ export default function CSVExport ({ filename, data }) {
     { label: 'Changesets', key: 'changeset_count' },
     { label: 'Edits', key: 'edit_count' }
   ]
-  if (data[0].campaignCount) {
+  if (isUser) {
     headers.splice(1, 0,
       { label: 'Campaigns', key: 'campaignCount' },
       { label: 'Badges', key: 'badgeCount' },
       { label: 'Countries', key: 'country_list.length' }
     )
   }
+
+  // Construct footer for the campaign table export
+  if (!isUser) {
+    let exportTotals = {}
+
+    const headerKeys = headers.map(e => e.key)
+    headerKeys.forEach(k => {
+      exportTotals[k] = formatDecimal(
+        data
+          .map(row => Number(row[k]))
+          .reduce((prev, cur) => prev + cur)
+      )
+    })
+
+    // Add name column
+    exportTotals['name'] = 'Total'
+    totalData = [...data, exportTotals]
+  }
+
   return (
     <CSVLink
       className='button button--secondary'
-      data={data}
+      data={totalData}
       filename={filename}
       headers={headers}
     >

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -85,7 +85,7 @@ export default function CampaignTable (props) {
       <Table idMap={idMap} tableSchema={tableSchema} data={campaignTopStats} totals={campaignTotals} initialSortColumn='edit_count' />
       <div>
         <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
-        <CSVExport filename={props.name} data={campaignTopStats} />
+        <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} />
       </div>
     </div>
   )


### PR DESCRIPTION
Closes #489 

To test:
- Open any campaign in scoreboard
- Download CSV export from campaign table
- Ensure that totals in export match totals in Campaign Table (noting that the web platform table combines `add`+ `mod`)
- Download CSV export from a user
- Ensure that user download does _not_ include total row