### PR TITLE
Fix/blank state user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
-- Update node version to 12.14LTS
-- Right-align table headers and cells with numeric data, excepting first "Rank" column
-
 ### Added
 - Settings Admin Page
 - Memory cache for settings
@@ -20,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User extent tiles now provided by s3 and tileserver proxy
 - Osmesa service now reads settings from cache
 - Right-align table headers and cells with numeric data, excepting first "Rank" column
+- Update node version to 12.14LTS
 
 ### Fixed
 - Refactor stylesheets for modular scss best practices, added stylelint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Memory cache for settings
 - Added blank state illustration for users with no edits
 - Added "Total" row for campaign tables, calculating all campaign stat totals
+- Add CLI tool to allow user to assign random edits to their user for development
 
 ### Changed 
 - User extent tiles now provided by s3 and tileserver proxy

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ Make your user an admin by running:
 
 If you were already logged in, log out and log back in, then you'll see an "admin" link in the menu in the top right.
 
+### Add some edits to your user
+
+It could be useful to give some edits to your user in development.
+
+You can run:
+
+```
+./api/bin/scoreboard create-edits --osm-id {your osm id}
+```
+
+This will select some random changesets from the OSMesa edits and assign them to your osm id
+
 ## Serve
 
 This command will start both the frontend and the api together

--- a/api/bin/commands/create-edits.js
+++ b/api/bin/commands/create-edits.js
@@ -1,0 +1,91 @@
+const dbSettings = require('../../src/models/settings')
+const db = require('../../src/db/connection')
+const { cache } = require('../../src/config')
+const knex = require('knex')
+
+/**
+ * Print usage of this command
+ */
+function printUsage () {
+  console.error('--osm-id required')
+}
+
+/**
+ * Command to assign edits to a user
+ * Takes a random user from fabricator and copies over random statistics
+ * for the supplied user
+ */
+async function command (args, flags) {
+  const { osmId } = flags
+
+  if (!osmId) {
+    printUsage()
+    return process.exit(1)
+  }
+
+  try {
+    // Check if this user has logged in before to scoreboard
+    const [user] = await db('users').where('osm_id', osmId)
+    if (!user) {
+      console.error(`This user doesn't exist in the Scoreboard database.`)
+      return process.exit(1)
+    }
+
+    // Grab the encrypted settings and put them in the cache to decrypt
+    const settings = await dbSettings.list()
+    settings.forEach(({ setting, value }) => {
+      cache.put(setting, value)
+    })
+
+    const osmesaDBURL = cache.get('osmesa-db')
+    const osmesaDB = await knex({ client: 'pg', connection: osmesaDBURL })
+
+    // Check if this user already has edits in osmesa
+    const [osmesaUser] = await osmesaDB('users').where('id', osmId)
+    if (osmesaUser) {
+      console.error(`This user already has statistics in the OSMesa database`)
+      return process.exit(1)
+    }
+
+    // Clone the changesets and assign them all to the new user
+    const changesets = await osmesaDB('changesets').select().orderByRaw('random()').limit(10)
+    const newChangesets = []
+    changesets.forEach(c => {
+      const newChangeset = Object.assign({}, c)
+      newChangeset.user_id = osmId
+      newChangesets.push(newChangeset)
+    })
+
+    const insertPromises = newChangesets.map(c =>
+      osmesaDB('changesets').where('id', c.id).update(c).returning('id'))
+    await Promise.all(insertPromises)
+
+    // get the user's displayname from the scoreboard db
+    // add the user to osmesa
+    await osmesaDB('users').insert({ id: user.osm_id, name: user.full_name })
+
+    // refresh the materialized views
+    await osmesaDB.schema.raw(`REFRESH MATERIALIZED VIEW hashtag_statistics`)
+    await osmesaDB.schema.raw(`REFRESH MATERIALIZED VIEW country_statistics`)
+    await osmesaDB.schema.raw(`REFRESH MATERIALIZED VIEW user_statistics`)
+    await osmesaDB.schema.raw(`REFRESH MATERIALIZED VIEW hashtag_user_statistics`)
+
+    await osmesaDB.destroy()
+    process.exit()
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+const args = []
+
+const flags = [
+  {
+    name: 'osm-id',
+    alias: 'osmId',
+    type: 'integer'
+  }
+]
+
+module.exports = { command, args, flags }

--- a/components/dashboard/DashboardBlurb.js
+++ b/components/dashboard/DashboardBlurb.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '../../components/Link'
 import { formatDecimal, formatKm } from '../../lib/utils/format'
 import { compareAsc, getYear } from 'date-fns'
 import { head } from 'ramda'
@@ -33,7 +34,7 @@ export default function Blurb ({
     countryWord = 'country'
   }
   if (isNaN(firstYearEdited)) {
-    return <h2 className='header--small width--shortened list--block'>{(username) ? `${username} has` : 'You have'} not made any mapping edits in {project} yet. Explore <a href='/campaigns'>active campaigns</a> to get started!</h2>
+    return <h2 className='header--small width--shortened list--block'>{(username) ? `${username} has` : 'You have'} not made any mapping edits in {project} yet. Explore <Link href='/campaigns'>active campaigns</Link> to get started!</h2>
   } else {
     return <h2 className='header--small width--shortened list--block'>
       Since <mark>{firstYearEdited}</mark>, {sentence} <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_railways_add + km_railways_mod)}</mark> of railways, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways in <mark>{country_list.length}</mark> <mark>{countryWord}</mark>.

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -130,7 +130,7 @@ class Dashboard extends Component {
       accountId = authenticatedUser.account.id
     }
     const recordsExport = [{ ...account.records, badgeCount, campaignCount, name }]
-    const userHasEdits = edit_times > 0 
+    const userHasEdits = edit_times > 0
     const userHasCampaigns = (favorites.length > 0 || assignments.length > 0 || campaignCount > 0)
     return (
       <div className='dashboard'>
@@ -155,57 +155,57 @@ class Dashboard extends Component {
         <div id='blurb' className='row'>
           <DashboardBlurb {...osmesaData} project={project} />
           <div className='widget-33 page-actions'>
-            {userHasEdits && 
+            {userHasEdits &&
               <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
             }
           </div>
         </div>
         {
-          (userHasCampaigns || isAdmin(authenticatedUser.account.roles)) 
-          && <section id='admin-assignments' className='section--dark'>
-              <div className='row'>
-                {isAdmin(authenticatedUser.account.roles) && this.renderAdmin()}
-                {userHasCampaigns && this.renderAssignments()}
-              </div>
-            </section>
+          (userHasCampaigns || isAdmin(authenticatedUser.account.roles)) &&
+          <section id='admin-assignments' className='section--dark'>
+            <div className='row'>
+              {isAdmin(authenticatedUser.account.roles) && this.renderAdmin()}
+              {userHasCampaigns && this.renderAssignments()}
+            </div>
+          </section>
         }
         {
           userHasEdits
             ? <>
-                <section id='dashboard_map'>
-                  <div className='row'>
-                    <div className='map-lg'>
-                      <UserExtentMap uid={uid} extent={extent_uri} />
+              <section id='dashboard_map'>
+                <div className='row'>
+                  <div className='map-lg'>
+                    <UserExtentMap uid={uid} extent={extent_uri} />
+                  </div>
+                </div>
+              </section>
+              <section id='dashboard_charts'>
+                <div className='row'>
+                  <div className='widget-container'>
+                    <div className='widget-66'>
+                      <CampaignsChart
+                        campaigns={allCampaigns}
+                        hashtags={hashtags}
+                        height='260px'
+                      />
+                    </div>
+                    <div className='widget-33'>
+                      <EditBreakdownChart {...breakdownChartProps} height='260px' />
                     </div>
                   </div>
-                </section>
-                <section id='dashboard_charts'>
-                  <div className='row'>
-                    <div className='widget-container'>
-                      <div className='widget-66'>
-                        <CampaignsChart
-                          campaigns={allCampaigns}
-                          hashtags={hashtags}
-                          height='260px'
-                        />
-                      </div>
-                      <div className='widget-33'>
-                        <EditBreakdownChart {...breakdownChartProps} height='260px' />
-                      </div>
-                    </div>
+                </div>
+              </section>
+              <section id='dashboard_sidebar-badges-heatmap'>
+                <div className='row widget-container'>
+                  <DashboardSidebar teams={teams} osmesaData={osmesaData} loggedIn={loggedIn} />
+                  <div className='widget-75'>
+                    <DashboardBadges badges={badges} name={name} />
                   </div>
-                </section>
-                <section id='dashboard_sidebar-badges-heatmap'>
-                  <div className='row widget-container'>
-                    <DashboardSidebar teams={teams} osmesaData={osmesaData} loggedIn={loggedIn} />
-                    <div className='widget-75'>
-                      <DashboardBadges badges={badges} name={name} />
-                    </div>
-                  </div>
-                  <div className='row'>
-                    <CalendarHeatmap times={edit_times} />
-                  </div>
-                </section>
+                </div>
+                <div className='row'>
+                  <CalendarHeatmap times={edit_times} />
+                </div>
+              </section>
               </>
             : this.renderBlankState()
         }

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -130,7 +130,7 @@ class Dashboard extends Component {
       accountId = authenticatedUser.account.id
     }
     const recordsExport = [{ ...account.records, badgeCount, campaignCount, name }]
-    const userHasEdits = edit_times > 0
+    const userHasEdits = edit_times.length > 0
     const userHasCampaigns = (favorites.length > 0 || assignments.length > 0 || campaignCount > 0)
     return (
       <div className='dashboard'>

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -109,7 +109,6 @@ class Dashboard extends Component {
         <NotLoggedIn message='Log in with your OSM account to see your personalized dashboard' />
       )
     }
-
     // Dashboard header variables
     let profileImage = null
     let name = null
@@ -131,6 +130,7 @@ class Dashboard extends Component {
       accountId = authenticatedUser.account.id
     }
     const recordsExport = [{ ...account.records, badgeCount, campaignCount, name }]
+    const userHasEdits = edit_times > 0 
     const userHasCampaigns = (favorites.length > 0 || assignments.length > 0 || campaignCount > 0)
     return (
       <div className='dashboard'>
@@ -155,73 +155,59 @@ class Dashboard extends Component {
         <div id='blurb' className='row'>
           <DashboardBlurb {...osmesaData} project={project} />
           <div className='widget-33 page-actions'>
-            {
-              edit_times > 0
-                ? <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
-                : <></>
+            {userHasEdits && 
+              <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
             }
           </div>
         </div>
         {
-          (userHasCampaigns || isAdmin(authenticatedUser.account.roles))
-            ? <section id='admin&assignments' className='section--dark'>
+          (userHasCampaigns || isAdmin(authenticatedUser.account.roles)) 
+          && <section id='admin-assignments' className='section--dark'>
               <div className='row'>
                 {isAdmin(authenticatedUser.account.roles) && this.renderAdmin()}
-                {
-                  (favorites.length > 0 || assignments.length > 0 || campaignCount > 1)
-                    ? <DashboardAssignments
-                      favorites={favorites}
-                      assignments={assignments}
-                      authenticatedUser={authenticatedUser}
-                      all={allCampaigns}
-                    />
-                    : <></>
-                }
+                {userHasCampaigns && this.renderAssignments()}
               </div>
             </section>
-            : <></>
         }
         {
-          edit_times > 0
+          userHasEdits
             ? <>
-              <section id='map'>
-                <div className='row'>
-                  <div className='map-lg'>
-                    <UserExtentMap uid={uid} extent={extent_uri} />
-                  </div>
-                </div>
-              </section>
-              <section id='charts'>
-                <div className='row'>
-                  <div className='widget-container'>
-                    <div className='widget-66'>
-                      <CampaignsChart
-                        campaigns={allCampaigns}
-                        hashtags={hashtags}
-                        height='260px'
-                      />
-                    </div>
-                    <div className='widget-33'>
-                      <EditBreakdownChart {...breakdownChartProps} height='260px' />
+                <section id='dashboard_map'>
+                  <div className='row'>
+                    <div className='map-lg'>
+                      <UserExtentMap uid={uid} extent={extent_uri} />
                     </div>
                   </div>
-                </div>
-              </section>
-              <section id='sidebar-badges-heatmap'>
-                <div className='row widget-container'>
-                  <DashboardSidebar teams={teams} osmesaData={osmesaData} loggedIn={loggedIn} />
-                  <div className='widget-75'>
-                    <DashboardBadges badges={badges} name={name} />
+                </section>
+                <section id='dashboard_charts'>
+                  <div className='row'>
+                    <div className='widget-container'>
+                      <div className='widget-66'>
+                        <CampaignsChart
+                          campaigns={allCampaigns}
+                          hashtags={hashtags}
+                          height='260px'
+                        />
+                      </div>
+                      <div className='widget-33'>
+                        <EditBreakdownChart {...breakdownChartProps} height='260px' />
+                      </div>
+                    </div>
                   </div>
-                </div>
-                <div className='row'>
-                  <CalendarHeatmap times={edit_times} />
-                </div>
-              </section>
-        </>
-            : <section className='row'>
-              <img className='img--blank-state' src='static/dashboard-temp/open_maps.svg' />
-            </section>
+                </section>
+                <section id='dashboard_sidebar-badges-heatmap'>
+                  <div className='row widget-container'>
+                    <DashboardSidebar teams={teams} osmesaData={osmesaData} loggedIn={loggedIn} />
+                    <div className='widget-75'>
+                      <DashboardBadges badges={badges} name={name} />
+                    </div>
+                  </div>
+                  <div className='row'>
+                    <CalendarHeatmap times={edit_times} />
+                  </div>
+                </section>
+              </>
+            : this.renderBlankState()
         }
       </div>
     )
@@ -240,6 +226,27 @@ class Dashboard extends Component {
         <br />
         <br />
       </div>
+    )
+  }
+
+  renderAssignments () {
+    const { authenticatedUser } = this.props
+    const { assignments, favorites, allCampaigns } = authenticatedUser.account
+    return (
+      <DashboardAssignments
+        favorites={favorites}
+        assignments={assignments}
+        authenticatedUser={authenticatedUser}
+        all={allCampaigns}
+      />
+    )
+  }
+
+  renderBlankState () {
+    return (
+      <section className='row'>
+        <img className='img--blank-state' src='static/dashboard-temp/open_maps.svg' />
+      </section>
     )
   }
 }

--- a/pages/user.js
+++ b/pages/user.js
@@ -90,6 +90,7 @@ export class User extends Component {
       ],
       records
     )
+    const userHasEdits = records.edit_count > 0
     const recordsExport = [{ ...records, badgeCount, campaignCount }]
     return (
       <div className='dashboard'>
@@ -112,43 +113,59 @@ export class User extends Component {
         <div className='row'>
           <DashboardBlurb {...records} username={name} />
           <div className='widget-33 page-actions'>
-            <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
+            {userHasEdits 
+              && <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
+            }
           </div>
         </div>
-        <section>
-          <div className='row'>
-            <div className='map-lg'>
-              <UserExtentMap uid={uid} extent={extent_uri} />
-            </div>
-          </div>
-        </section>
-        <section>
-          <div className='row'>
-            <div className='widget-container'>
-              <div className='widget-66'>
-                <CampaignsChart
-                  hashtags={hashtags}
-                  height='260px'
-                />
-              </div>
-              <div className='widget-33'>
-                <EditBreakdownChart {...breakdownChartProps} height='260px' />
-              </div>
-            </div>
-          </div>
-        </section>
-        <section>
-          <div className='row widget-container'>
-            <DashboardSidebar teams={teams} osmesaData={records} />
-            <div className='widget-75'>
-              <DashboardBadges name={name} badges={badges} />
-            </div>
-          </div>
-          <div className='row'>
-            <CalendarHeatmap times={edit_times} />
-          </div>
-        </section>
+        {
+          userHasEdits
+            ? <>
+                <section id='user_map'>
+                  <div className='row'>
+                    <div className='map-lg'>
+                      <UserExtentMap uid={uid} extent={extent_uri} />
+                    </div>
+                  </div>
+                </section>
+                <section id='user_charts'>
+                  <div className='row'>
+                    <div className='widget-container'>
+                      <div className='widget-66'>
+                        <CampaignsChart
+                          hashtags={hashtags}
+                          height='260px'
+                        />
+                      </div>
+                      <div className='widget-33'>
+                        <EditBreakdownChart {...breakdownChartProps} height='260px' />
+                      </div>
+                    </div>
+                  </div>
+                </section>
+                <section id='user_sidebar-badges-heatmap'>
+                  <div className='row widget-container'>
+                    <DashboardSidebar teams={teams} osmesaData={records} />
+                    <div className='widget-75'>
+                      <DashboardBadges name={name} badges={badges} />
+                    </div>
+                  </div>
+                  <div className='row'>
+                    <CalendarHeatmap times={edit_times} />
+                  </div>
+                </section>
+              </>
+            : this.renderBlankState()
+        }
       </div>
+    )
+  }
+
+  renderBlankState () {
+    return (
+      <section className='row'>
+        <img className='img--blank-state' src='../static/dashboard-temp/open_maps.svg' />
+      </section>
     )
   }
 }

--- a/pages/user.js
+++ b/pages/user.js
@@ -113,47 +113,47 @@ export class User extends Component {
         <div className='row'>
           <DashboardBlurb {...records} username={name} />
           <div className='widget-33 page-actions'>
-            {userHasEdits 
-              && <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
+            {userHasEdits &&
+              <CSVExport filename={`${name}_ScoreboardData.csv`} data={recordsExport} />
             }
           </div>
         </div>
         {
           userHasEdits
             ? <>
-                <section id='user_map'>
-                  <div className='row'>
-                    <div className='map-lg'>
-                      <UserExtentMap uid={uid} extent={extent_uri} />
+              <section id='user_map'>
+                <div className='row'>
+                  <div className='map-lg'>
+                    <UserExtentMap uid={uid} extent={extent_uri} />
+                  </div>
+                </div>
+              </section>
+              <section id='user_charts'>
+                <div className='row'>
+                  <div className='widget-container'>
+                    <div className='widget-66'>
+                      <CampaignsChart
+                        hashtags={hashtags}
+                        height='260px'
+                      />
+                    </div>
+                    <div className='widget-33'>
+                      <EditBreakdownChart {...breakdownChartProps} height='260px' />
                     </div>
                   </div>
-                </section>
-                <section id='user_charts'>
-                  <div className='row'>
-                    <div className='widget-container'>
-                      <div className='widget-66'>
-                        <CampaignsChart
-                          hashtags={hashtags}
-                          height='260px'
-                        />
-                      </div>
-                      <div className='widget-33'>
-                        <EditBreakdownChart {...breakdownChartProps} height='260px' />
-                      </div>
-                    </div>
+                </div>
+              </section>
+              <section id='user_sidebar-badges-heatmap'>
+                <div className='row widget-container'>
+                  <DashboardSidebar teams={teams} osmesaData={records} />
+                  <div className='widget-75'>
+                    <DashboardBadges name={name} badges={badges} />
                   </div>
-                </section>
-                <section id='user_sidebar-badges-heatmap'>
-                  <div className='row widget-container'>
-                    <DashboardSidebar teams={teams} osmesaData={records} />
-                    <div className='widget-75'>
-                      <DashboardBadges name={name} badges={badges} />
-                    </div>
-                  </div>
-                  <div className='row'>
-                    <CalendarHeatmap times={edit_times} />
-                  </div>
-                </section>
+                </div>
+                <div className='row'>
+                  <CalendarHeatmap times={edit_times} />
+                </div>
+              </section>
               </>
             : this.renderBlankState()
         }


### PR DESCRIPTION
Fixes issue with #467 where user dashboard displays blank state illustration, in place of badges/heatmap/calendar, at all times. 

To test:
1. ensure that blank state does display on dashboards of users that have no edits, admins with no edits, and public profiles with no edits
2. ensure that blank state does **not** display on dashboards of user, admins and public profiles with edits
3. ensure that regardless of ^above, campaign assignment table displays on user and admin dashboards when favorites, assignments or contributed campaigns exist
4. ensure that regardless of 1 and 2, admin widgets display on admins' dashboards 

My dashboard, no campaign assignments or admin rights:
![image](https://user-images.githubusercontent.com/12634024/73308943-4c38c700-41ef-11ea-89f1-ec49932ded94.png)

My dashboard, with campaign favorites:
![image](https://user-images.githubusercontent.com/12634024/73308224-c9633c80-41ed-11ea-9cd3-b5ff0c7d4893.png)

My dashboard, with campaign favorites and admin rights:
![image](https://user-images.githubusercontent.com/12634024/73309489-50b1af80-41f0-11ea-9f1b-f8ca9d4acfba.png)

My public profile:
![image](https://user-images.githubusercontent.com/12634024/73308260-df70fd00-41ed-11ea-8110-d9194ef35623.png)
