### PR TITLE
Update Readme, default environment vars, and .env.sample.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,14 +1,54 @@
-NODE_ENV=development
-#TM_URL=https://tasking-manager-url
-#TM_HASHTAG=tasking-manager-prefix
-#OSMESA_API=https://link-to-osmesa-api
-#APP_URL=http://localhost:8181
-OSM_CONSUMER_KEY=your-oauth-key
-OSM_CONSUMER_SECRET=your-oauth-secre
-OSM_DOMAIN=https://www.openstreetmap.org
-SESSION_SECRET=super-secret-sessions
-DATABASE_URL=postgres://scoreboard:test@localhost:5433/scoreboard
-OSM_TEAMS_SERVICE=http://localhost:8989
-OSM_TEAMS_SERVICE_TOKEN_URL=http://localhost:4445
-OSM_TEAMS_CLIENT_ID=teams-oauth-key
-OSM_TEAMS_CLIENT_SECRET=teams-oauth-secret
+################################################################################
+#
+# Required environment variables (replace **** with your real values)
+#
+
+# oAuth key/secret pair to authenticate with OSM. Generate the pair 
+# at openstreetmap.org -> My Settings -> oAuth Settings -> Register a new app.
+OSM_CONSUMER_KEY=****
+OSM_CONSUMER_SECRET=****
+
+# oAuth key/secret pair to authenticate with OSM-teams. Generate the pair
+# at https://mapping.team/ -> Connect a new app.
+OSM_TEAMS_CLIENT_ID=****
+OSM_TEAMS_CLIENT_SECRET=****
+
+################################################################################
+#
+# Optional environment variables (the default value is shown)
+# The uuidgen utility may be useful for production secrets.
+#
+
+# The build configuration to use, "test", "development" or "production"
+# NODE_ENV=development
+
+# A secret phrase to sign session tokens. Change this for production! 
+# SESSION_SECRET=changeme!
+
+# A secret phrase used to initialize cryptographic functions. Change this for production!
+# APP_SECRET=changeme!........(32 characters)
+
+# URL where the site will be hosted. Defaults to local development url.
+# APP_URL=http://localhost:8181
+# APP_URL_PREFIX=/
+
+# OSM URL. Only change this for a private OSM enclaves.
+# OSM_DOMAIN=https://www.openstreetmap.org
+
+# For cases where the OSM deployment is behind a firewall
+# OSM_DOMAIN_INTERNAL=https://www.openstreetmap.org
+
+# URL of the PostgreSQL database. Will be overridden for test environment.
+# DATABASE_URL=postgres://scoreboard:test@localhost:5433/scoreboard
+
+# URL for OSM teams API. Defaults to local development url.
+# OSM_TEAMS_SERVICE=http://localhost:8989
+
+# Additional OSM Teams URLs and paths for customizing production deployments.
+# OSM_TEAMS_SERVICE_TOKEN_HOST=http://localhost:4444
+# OSM_TEAMS_SERVICE_TOKEN_PATH=/oauth2/token
+# OSM_TEAMS_SERVICE_AUTHZ_HOST=http://localhost:4444
+# OSM_TEAMS_SERVICE_AUTHZ_PATH=/oauth2/auth
+
+# Displayed on the home page.
+# PROJECT_NAME=OpenStreetMap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+Added
+
+- Added new sections to readme about osm-teams and administration settings.
+
+Changed
+
+- Cleaned up and improved comments in `.env.sample`.
+- Removed environment variables from README. Instead use `.env.sample` as a reference.
+
+Fixed
+
+- n/a
+
+
 ## [v1.8.0] - 2020-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Engaging and encouraging mappers of OpenStreetMap by rewarding contributions, pr
 # 🔨 Development
 
 ## Dependencies
+
 - Node 12.14.x
 - Postgres 9.5+
 - Yarn
@@ -32,42 +33,28 @@ To set the Node version as specified above:
 See [this tutorial](https://www.postgresql.org/download/) for details and instructions for installing PostgreSQL on your operating system
 
 ### Services
+
 Scoreboard depends on three external services/APIs for statistics and functionality:
 - [OSMesa](https://github.com/azavea/osmesa) is a toolkit for processing large amounts of OSM vector data and turning them into stats (e.g: km of road added by user by country)
 - Scoreboard pulls campaigns from the [Tasking Manager](https://github.com/hotosm/tasking-manager) and uses the campaign hashtags to pull campaign specific aggregations from OSMesa
 - [OSM Teams](https://github.com/developmentseed/osm-teams) is a service that allows Scoreboard users to create teams and assign campaigns to a team.
 
-### Env file
+### Environment file
 
-There should be an env file in the root project directory with the following environment variables.
+Create a `.env` file by copying the `.env.sample` file and filling in the
+required values. The sample file has comments above each possible environment
+variable.
 
-| name | description
-| ---  | -----
-| NODE_ENV | The configuration to use, "test", "development" or "production"
-| APP_URL | URL where the site will be hosted
-| OSM_CONSUMER_KEY | An Oauth Key/Secret pair to authenticate with OSM
-| OSM_CONSUMER_SECRET | An Oauth Key/Secret pair to authenticate with OSM
-| OSM_DOMAIN | OSM endpoint (defaults to openstreetmap.com)
-| OSM_TEAMS_SERVICE | Location of the OSM teams API
-| OSM_TEAMS_CLIENT_ID | Client id for OSM Teams authentication
-| OSM_TEAMS_CLIENT_SECRET | Client secret for OSM Teams authentication
-| OSM_TEAMS_TOKEN_HOST | Location of OSM Teams token endpoint (e.g http://osm-teams)
-| OSM_TEAMS_TOKEN_PATH | Location of OSM Teams token path (e.g /oauth2/token)
-| OSM_TEAMS_AUTHZ_HOST | Location of OSM Teams authorization endpoint (e.g http://osm-teams)
-| OSM_TEAMS_AUTHZ_PATH | Location of OSM Teams authorization path (e.g /oauth2/auth)
-| SESSION_SECRET | A secret phrase to sign session tokens
-| DATABASE_URL | The location of the postgres database
+- See [Connecting to OSM Teams](#connecting-to-osm-teams)
+- See [Administrator Settings](#administrator-settings)
 
-Once the Scoreboard app is running, you can add a tasking manager in the admin panel
-
-
-## Installation and Dev
+## Install JavaScript Dependencies
 
      $ yarn
 
-## Postgres Setup
+## Database Setup
 
-### Create and Run the database
+### Create and run the database
 
      $ docker-compose up -d
 
@@ -77,7 +64,7 @@ If you are running the command for the first time, you should wait until the dat
 
 To start with a new database with no data, stop the command, remove the `.tmp` folder and run the command again.
 
-### Run migrations
+### Run database migrations
 
 Set up the database schema by running:
 
@@ -85,7 +72,8 @@ Set up the database schema by running:
 
 You can rollback migrations with `yarn rollback`.
 
-### Populate Data
+### Populate database
+
 For the frontend and the API to work, you must have the data loaded on the local database.
 
 To generate fake user and campaign data run:
@@ -95,7 +83,6 @@ To generate fake user and campaign data run:
 ### Create an admin user
 
 To be able to develop admin pages you'll need to have an admin user.
-
 Make your user an admin by running:
 
 ```
@@ -103,6 +90,8 @@ Make your user an admin by running:
 ```
 
 If you were already logged in, log out and log back in, then you'll see an "admin" link in the menu in the top right.
+
+Known issue: before running `create-admin-user` for username, you first have to login to the web app with that username first.
 
 ### Add some edits to your user
 
@@ -116,13 +105,13 @@ You can run:
 
 This will select some random changesets from the OSMesa edits and assign them to your osm id
 
-## Serve
+## Start Development Server
 
 This command will start both the frontend and the api together
 
      $ yarn dev
 
-## Test
+## Tests
 
 Tests for the API endpoints and related code are stored in [api/tests/](api/tests/) and UI tests are stored in [tests/](tests/). To run both:
 
@@ -130,7 +119,7 @@ Tests for the API endpoints and related code are stored in [api/tests/](api/test
 
 Test the UI and API separately using `yarn test-ui` and `yarn test-api`.
 
-## Lint
+## Linter
 
 Lint the code using:
 
@@ -144,20 +133,41 @@ If you make changes to the API documentation make sure to update the README for 
 
      $ yarn docs
 
+## Connecting to OSM Teams
+
+In OSM-teams, choose "Connect a new app". For the callback URL use the path
+`/auth/teams/accept`
+
+For example in development, Scoreboard runs on localhost:8181, so the
+callback URL would be `http://localhost:8181/auth/teams/accept` .
+
+The client id and client secret should be saved to your Scoreboard `.env` file.
+
+# Administrator Settings
+
+The Administrator Settings are found in the Admin user's dashboard, or
+via the Admin entry in the User menu.
+
+- Tasking Managers:  Currently HOT Tasking Manager (TM2 - TM3) is supported.
+- Setup Badges
+- Manage Users
+- App Settings: OSMesa integration settings
+
 # Production
 
 To use scoreboard in production follow these steps:
 
 1. Make sure you have all the [requirements](#dependencies).
-2. Install dependencies: `yarn`
-3. Setup a production Postgres database
-4. Create the database by running [these commands](scripts/create-dev-db.sh).
-5. Setup an `.env` file with correct values -> [example](.env.sample).
-  - make sure to set `NODE_ENV=production` in your `.env` file
-6. Run the migrations: `npm run migrate`
-7. Add initial data to the database (skip if the database already has data) `npm run seed`
-8. [OPTIONAL] Preload list of users `npm run users`
-9. Populate stats: `npm run clocks`
-10. [OPTIONAL] Assign admin users by running `./api/bin/scoreboard create-admin-user --osm-id {your-id}`
-11. Build: `npm run build`
-12. Launch the server: `node server.js`
+1. Install dependencies: `yarn`
+1. Setup a production Postgres database
+1. Create the database by running [these commands](scripts/create-dev-db.sh).
+1. Setup an `.env` file with correct values -> [example](.env.sample).
+   - make sure to set `NODE_ENV=production` in your `.env` file
+1. Run the migrations: `npm run migrate`
+1. Add initial data to the database (skip if the database already has data) `npm run seed`
+1. [OPTIONAL] Preload list of users `npm run users`
+1. Populate stats: `npm run clocks`
+1. [OPTIONAL] Assign admin users by running `./api/bin/scoreboard create-admin-user --osm-id {your-id}`
+   - Note: 
+1. Build: `npm run build`
+1. Launch the server: `node server.js`

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -11,7 +11,7 @@ let final = join(appUrl, prefix)
 // add a trailing slash if it is missing
 if (final[final.length - 1] !== '/') final += '/'
 
-const APP_SECRET = process.env.APP_SECRET || '38ubHTGCBDzWDZvFFBVVKopafwRvVfCC'
+const APP_SECRET = process.env.APP_SECRET || 'changeme!........(32 characters)'
 const cryptr = new Cryptr(APP_SECRET)
 
 if (process.env.NODE_ENV === 'test') {
@@ -28,7 +28,7 @@ module.exports = {
   APP_URL: appUrl,
   APP_URL_PREFIX: prefix,
   APP_URL_FINAL: final,
-  APP_SECRET: process.env.APP_SECRET || 'super-secret-secret',
+  APP_SECRET,
   OSM_CONSUMER_KEY: process.env.OSM_CONSUMER_KEY,
   OSM_CONSUMER_SECRET: process.env.OSM_CONSUMER_SECRET,
   OSM_DOMAIN: process.env.OSM_DOMAIN || 'https://www.openstreetmap.org',
@@ -42,6 +42,6 @@ module.exports = {
   PROJECT_NAME: process.env.PROJECT_NAME || 'OpenStreetMap',
   // to handle cases where the OSM deployment is behind a firewall
   OSM_DOMAIN_INTERNAL: process.env.OSM_DOMAIN_INTERNAL || process.env.OSM_DOMAIN || 'https://www.openstreetmap.org',
-  SESSION_SECRET: process.env.SESSION_SECRET || 'SUPER SECRET',
+  SESSION_SECRET: process.env.SESSION_SECRET || 'changeme!',
   DATABASE_URL
 }


### PR DESCRIPTION
- Improve headings and structure of markdown
- Clean up `.env.sample` and add more comments
- Add section to Readme about osm-teams integration
- Add section to Readme about administrator settings
- Remove environment variables from Readme because they were outdated/wrong (.env.sample is the canonical source now)
- Remove apparent crypto seed from api/src/config.js
- Update all secret default values to start with 'changeme!'

Closes #476 
