### PR TITLE
Add team statistics to teams route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Added
 
 - Added new sections to readme about osm-teams and administration settings.
+- Added an osmesaStats data structure to the response in route /teams:id.
 
 Changed
 

--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -76,7 +76,7 @@ async function get (req, res) {
       'campaigns.tasker_id', '=', 't.taskers_t_id')
     const teamMemberOsmIds = teamData.members.map(m => m.id)
     const users = await db('users').whereIn('osm_id', teamMemberOsmIds)
-    const teamStats = OSMesa.getTeamStats(teamMemberOsmIds)
+    const osmesaStats = await OSMesa.getTeamStats(teamMemberOsmIds)
     const team = {
       id: teamData.id,
       bio: teamData.bio,
@@ -84,7 +84,7 @@ async function get (req, res) {
       name: teamData.name,
       campaigns,
       users,
-      stats: teamStats
+      osmesaStats
     }
     return res.send(team)
   } catch (err) {

--- a/api/src/services/osmesa.js
+++ b/api/src/services/osmesa.js
@@ -1,7 +1,15 @@
+const pg = require('pg')
+// conversion of postgresql bigint (int8) to JS number (from https://github.com/knex/knex/issues/387)
+pg.types.setTypeParser(pg.types.builtins.INT8, 'text', parseInt)
 const knex = require('knex')
 const AWS = require('aws-sdk')
-
-const { find, propEq, reduce, assoc } = require('ramda')
+const {
+  assoc,
+  find,
+  propEq,
+  reduce,
+  sum
+} = require('ramda')
 
 const { cache } = require('../config')
 
@@ -48,6 +56,151 @@ const osmesaUserObj = {
 
 module.exports.osmesaUserObj = osmesaUserObj
 
+const editTypes = [
+  ['added', 'add'],
+  ['modified', 'mod'],
+  ['deleted', 'del']
+]
+
+const countConversions = [
+  ['roads', 'roads'],
+  ['waterways', 'waterways'],
+  ['coastlines', 'coastlines'],
+  ['buildings', 'buildings'],
+  ['pois', 'poi'],
+  ['raillines', 'railways']
+]
+
+const measurementConversions = [
+  ['road', 'roads'],
+  ['waterway', 'waterways'],
+  ['coastline', 'coastlines'],
+  ['railline', 'railways']
+]
+
+function expandCountObj (type, obj) {
+  return Object.keys(obj).map((key) => {
+    return {
+      [type]: type === 'user' ? Number(key) : key,
+      count: obj[key]
+    }
+  })
+}
+
+/**
+ * Convert osmesa measurement properties to the shape required by Scoreboard app.
+ *
+ * Warning: modifies the target object in addition to returning it!
+ *
+ * @param {Object} target
+ * @param {Object} source
+ * @returns {Object} converted target object
+ */
+function convertMeasurementProperties (target, source) {
+  measurementConversions.forEach(meas => {
+    editTypes.forEach(type => {
+      if (
+        target &&
+        source &&
+        source.measurements &&
+        source.measurements[`${meas[0]}_km_${type[0]}`]
+      ) {
+        target[`km_${meas[1]}_${type[1]}`] = source.measurements[`${meas[0]}_km_${type[0]}`]
+      } else {
+        target[`km_${meas[1]}_${type[1]}`] = 0
+      }
+    })
+  })
+  return target
+}
+
+/**
+ * Convert osmesa count properties to the shape required by scoreboard app.
+ *
+ * Warning: modifies the target object in addition to returning it!
+ *
+ * @param {Object} target
+ * @param {Object} source
+ * @returns {Object} converted target object
+ */
+function convertCountProperties (target, source) {
+  countConversions.forEach(count => {
+    editTypes.forEach(type => {
+      if (
+        target &&
+          source &&
+          source.counts &&
+          source.counts[`${count[0]}_${type[0]}`]
+      ) {
+        target[`${count[1]}_${type[1]}`] = source.counts[`${count[0]}_${type[0]}`]
+      } else {
+        target[`${count[1]}_${type[1]}`] = 0
+      }
+    })
+  })
+  return target
+}
+
+/**
+ * Convert user object from osmesa shape to what is required by scoreboard app.
+ *
+ * @param {Array} countries result set from osmesa countries table
+ * @param {Object} osmesaUserStats object from osmesa user_statistics table
+ * @returns {Object} converted user object
+ */
+function convertUserObjectShape (countries, osmesaUserStats) {
+  const {
+    id: uid,
+    edit_count,
+    changeset_count,
+    name,
+    last_edit,
+    editor_edits,
+    day_edits,
+    hashtag_edits,
+    hashtag_changesets,
+    country_edits,
+    country_changesets
+  } = osmesaUserStats
+
+  const country_list = []
+  Object.keys(country_edits).forEach(code => {
+    const countryName = find(propEq('code', code))(countries).name
+    country_list.push({
+      name: countryName,
+      edit_count: country_edits[code],
+      changeset_count: country_changesets[code]
+    })
+  })
+
+  const hashtags = Object.keys(hashtag_edits).map(hashtag => {
+    return {
+      tag: hashtag,
+      edit_count: hashtag_edits[hashtag],
+      changeset_count: hashtag_changesets[hashtag]
+    }
+  })
+
+  const editors = expandCountObj('editor', editor_edits)
+  const edit_times = expandCountObj('day', day_edits)
+
+  const userObj = {
+    uid,
+    name,
+    edit_count,
+    changeset_count,
+    last_edit,
+    editors,
+    edit_times,
+    hashtags,
+    country_list
+  }
+
+  convertCountProperties(userObj, osmesaUserStats)
+  convertMeasurementProperties(userObj, osmesaUserStats)
+  return userObj
+}
+
 class OSMesaDBWrapper {
   constructor () {
     // connection the odmesa db
@@ -57,27 +210,6 @@ class OSMesaDBWrapper {
     // connection to s3
     this.s3bucket = null
     this.s3client = null
-
-    this.editTypes = [
-      ['added', 'add'],
-      ['modified', 'mod'],
-      ['deleted', 'del']
-    ]
-
-    this.countConversions = [
-      ['roads', 'roads'],
-      ['waterways', 'waterways'],
-      ['coastlines', 'coastlines'],
-      ['buildings', 'buildings'],
-      ['pois', 'poi']
-    ]
-
-    this.measurementConversions = [
-      ['road', 'roads'],
-      ['waterway', 'waterways'],
-      ['coastline', 'coastlines'],
-      ['railline', 'railways']
-    ]
   }
 
   db (tableName) {
@@ -112,115 +244,83 @@ class OSMesaDBWrapper {
     }).createReadStream()
   }
 
-  // turns the new schema into the old schema for objects like user_edits
-  expandCountObj (type, obj) {
-    return Object.keys(obj).map((key) => {
-      return {
-        [type]: type === 'user' ? Number(key) : key,
-        count: obj[key]
-      }
-    })
-  }
-
-  convertCountProperties (target, source) {
-    this.countConversions.forEach(count => {
-      this.editTypes.forEach(type => {
-        if (
-          target &&
-          source &&
-          source.counts &&
-          source.counts[`${count[0]}_${type[0]}`]
-        ) {
-          target[`${count[1]}_${type[1]}`] = source.counts[`${count[0]}_${type[0]}`]
-        } else {
-          target[`${count[1]}_${type[1]}`] = 0
-        }
-      })
-    })
-
-    return target
-  }
-
-  convertMeasurementProperties (target, source) {
-    this.measurementConversions.forEach(meas => {
-      this.editTypes.forEach(type => {
-        if (
-          target &&
-          source &&
-          source.measurements &&
-          source.measurements[`${meas[0]}_km_${type[0]}`]
-        ) {
-          target[`km_${meas[1]}_${type[1]}`] = source.measurements[`${meas[0]}_km_${type[0]}`]
-        } else {
-          target[`km_${meas[1]}_${type[1]}`] = 0
-        }
-      })
-    })
-    return target
-  }
-
   async getUser (id) {
-    let [data] = await this.db('user_statistics').where({ id })
-    let countries = await this.db('countries').select()
+    const [data] = await this.db('user_statistics').where({ id })
+    const countries = await this.db('countries').select()
+    return convertUserObjectShape(countries, data)
+  }
 
-    // change shape of response
-    const {
-      edit_count,
-      changeset_count,
-      name,
-      last_edit,
-      editor_edits,
-      day_edits,
-      hashtag_edits,
-      hashtag_changesets,
-      country_edits,
-      country_changesets
-    } = data
-
-    let country_list = []
-    Object.keys(country_edits).forEach(code => {
-      const countryName = find(propEq('code', code))(countries).name
-      country_list.push({
-        name: countryName,
-        edit_count: country_edits[code],
-        changeset_count: country_changesets[code]
-      })
+  /**
+   * Get aggregate data for a list of OSM ids (e.g. all the team members),
+   * Includes original user statistics in the response as well.
+   *
+   * @param {Array} userIds - OSM user Ids of team members
+   * @returns {Object} aggregate data and per-user statistics {teamStats, memberStats}
+   */
+  async getTeamStats (userIds) {
+    const userData = await this.db('user_statistics').whereIn('id', userIds)
+    const countries = await this.db('countries').select()
+    const memberStats = userData.map(data => convertUserObjectShape(countries, data))
+    const columnsToSum = [
+      'buildings_add',
+      'buildings_del',
+      'buildings_mod',
+      'changeset_count',
+      'coastlines_add',
+      'coastlines_del',
+      'coastlines_mod',
+      'edit_count',
+      'km_coastlines_add',
+      'km_coastlines_del',
+      'km_coastlines_mod',
+      'km_railways_add',
+      'km_railways_del',
+      'km_railways_mod',
+      'km_roads_add',
+      'km_roads_del',
+      'km_roads_mod',
+      'km_waterways_add',
+      'km_waterways_del',
+      'km_waterways_mod',
+      'poi_add',
+      'poi_del',
+      'poi_mod',
+      'railways_add',
+      'railways_del',
+      'railways_mod',
+      'roads_add',
+      'roads_del',
+      'roads_mod',
+      'waterways_add',
+      'waterways_del',
+      'waterways_mod'
+    ]
+    // sum all of the columns into teamStats
+    const teamStats = {}
+    columnsToSum.forEach(columnName => {
+      teamStats[columnName] = sum(memberStats.map(data => data[columnName]))
     })
+    // count the unique countries which were edited
+    const editedCountries = new Set()
+    memberStats.forEach(
+      ({ country_list }) => country_list.forEach(
+        ({ name }) => editedCountries.add(name)
+      )
+    )
+    teamStats.countryCount = editedCountries.size
 
-    let hashtags = Object.keys(hashtag_edits).map(hashtag => {
-      return {
-        tag: hashtag,
-        edit_count: hashtag_edits[hashtag],
-        changeset_count: hashtag_changesets[hashtag]
-      }
-    })
-
-    let editors = this.expandCountObj('editor', editor_edits)
-    let edit_times = this.expandCountObj('day', day_edits)
-
-    const userObj = {
-      uid: data.id,
-      name,
-      edit_count,
-      changeset_count,
-      last_edit,
-      editors,
-      edit_times,
-      hashtags,
-      country_list
+    const result = {
+      teamStats,
+      memberStats
     }
-
-    this.convertCountProperties(userObj, data)
-    this.convertMeasurementProperties(userObj, data)
-
-    return userObj
+    return result
   }
 
   async getCampaign (hashtag) {
     const [data] = await this.db('hashtag_statistics').where({ tag: hashtag })
     const userData = await this.db('hashtag_user_statistics').where({ hashtag })
 
-    let users = userData.map(user => {
+    const users = userData.map(user => {
       const userObj = {
         uid: user.user_id,
         name: user.name,
@@ -228,8 +328,8 @@ class OSMesaDBWrapper {
         changeset_count: user.changeset_count,
         last_edit: user.last_edit
       }
-      this.convertCountProperties(userObj, user)
-      this.convertMeasurementProperties(userObj, user)
+      convertCountProperties(userObj, user)
+      convertMeasurementProperties(userObj, user)
       return userObj
     })
 
@@ -241,8 +341,8 @@ class OSMesaDBWrapper {
       users
     }
 
-    this.convertCountProperties(campaignObj, data)
-    this.convertMeasurementProperties(campaignObj, data)
+    convertCountProperties(campaignObj, data)
+    convertMeasurementProperties(campaignObj, data)
     return campaignObj
   }
 
@@ -267,12 +367,12 @@ class OSMesaDBWrapper {
       updated_at,
       changeset_count,
       edit_count,
-      user_edits: this.expandCountObj('user', user_edits),
-      hashtag_edits: this.expandCountObj('hashtag', hashtag_edits)
+      user_edits: expandCountObj('user', user_edits),
+      hashtag_edits: expandCountObj('hashtag', hashtag_edits)
     }
 
-    this.convertCountProperties(countryObj, data)
-    this.convertMeasurementProperties(countryObj, data)
+    convertCountProperties(countryObj, data)
+    convertMeasurementProperties(countryObj, data)
     return countryObj
   }
 

--- a/api/tests/services/osmesadb.test.js
+++ b/api/tests/services/osmesadb.test.js
@@ -39,3 +39,58 @@ test.serial('get updates', async t => {
   const lastUpdated = await osmesa.getUpdates()
   t.truthy(lastUpdated)
 })
+
+test.serial('get team stats', async t => {
+  // these osmIds are not on a team actually, but the getTeamStats() just
+  // takes a list of osmIds which could also be the team members.
+  const osmIds = [33757, 19239]
+  const stats = await osmesa.getTeamStats(osmIds)
+  const { teamStats, memberStats } = stats
+  t.is(memberStats.length, 2)
+  const memberNames = memberStats.map(data => data.name)
+  t.true(memberNames.includes('Minh Nguyen'))
+  t.true(memberNames.includes('ebrelsford'))
+
+  const integerCheck = Number.isInteger
+  const floatCheck = x => typeof x === 'number'
+
+  const expectedTeamStats = {
+    buildings_add: integerCheck,
+    buildings_del: integerCheck,
+    buildings_mod: integerCheck,
+    changeset_count: integerCheck,
+    coastlines_add: integerCheck,
+    coastlines_del: integerCheck,
+    coastlines_mod: integerCheck,
+    countryCount: integerCheck,
+    edit_count: integerCheck,
+    km_coastlines_add: floatCheck,
+    km_coastlines_del: floatCheck,
+    km_coastlines_mod: floatCheck,
+    km_railways_add: floatCheck,
+    km_railways_del: floatCheck,
+    km_railways_mod: floatCheck,
+    km_roads_add: floatCheck,
+    km_roads_del: floatCheck,
+    km_roads_mod: floatCheck,
+    km_waterways_add: floatCheck,
+    km_waterways_del: floatCheck,
+    km_waterways_mod: floatCheck,
+    poi_add: integerCheck,
+    poi_del: integerCheck,
+    poi_mod: integerCheck,
+    railways_add: integerCheck,
+    railways_del: integerCheck,
+    railways_mod: integerCheck,
+    roads_add: integerCheck,
+    roads_del: integerCheck,
+    roads_mod: integerCheck,
+    waterways_add: integerCheck,
+    waterways_del: integerCheck,
+    waterways_mod: integerCheck
+  }
+  Object.keys(expectedTeamStats).forEach(k => {
+    const predicate = expectedTeamStats[k]
+    t.true(predicate(teamStats[k]), `unexpected ${k}`)
+  })
+})


### PR DESCRIPTION
Relates to #198,  #527 

- Adds an `osmesaStats` data structure to the response in route `/teams:id`
- Does not update `api.yml` because that is a larger task covered by #527 .

