### PR TITLE
Update centos/deploy.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- CentOS deployment script: deployment/centos/deploy.sh corrected and updated.
+
 ## [v1.8.0] - 2020-02-03
 
 ### Added

--- a/deployment/centos/deploy.sh
+++ b/deployment/centos/deploy.sh
@@ -10,26 +10,32 @@
 #
 
 GIT_TAG=${1:-master}
+NGINX_PATH=/var/www
 
 echo "using git tag or branch: ${GIT_TAG}"
 echo
 
 cd ~
+
+# find the tag or branch
 rm -rf scoreboard
 git clone https://github.com/developmentseed/scoreboard.git
-cd scoreboard
+pushd scoreboard
 git checkout ${GIT_TAG}
 
-# installation
+# install & build steps
 yarn install
 yarn run migrate
 yarn run build
+popd
 
-# move to nginx folder
-cd ../..
-suffix=$(date +%s)
-sudo mv /var/www/scoreboard /var/www/scoreboard_$suffix || echo 'this is the first deployment'
-sudo mv scoreboard /var/www/
+# update nginx directory
+datestamp=$(date +%F)
+if [ -d "${NGINX_PATH}/scoreboard" ]; then
+    # backup previous deployment
+    sudo mv -v ${NGINX_PATH}/scoreboard ${NGINX_PATH}/scoreboard_${datestamp}
+fi
+sudo mv -v scoreboard ${NGINX_PATH}
 
 # restart services
 sudo systemctl restart scoreboard-api

--- a/deployment/centos/deploy.sh
+++ b/deployment/centos/deploy.sh
@@ -13,9 +13,9 @@ cd scoreboard
 git checkout ${GIT_TAG}
 
 # installation
-npm install
-npm run migrate
-npm run build
+yarn install
+yarn run migrate
+yarn run build
 
 # move to nginx folder
 cd ../..

--- a/deployment/centos/deploy.sh
+++ b/deployment/centos/deploy.sh
@@ -38,7 +38,7 @@ fi
 sudo mv -v scoreboard ${NGINX_PATH}
 
 # restart services
-sudo systemctl restart scoreboard-api
-sudo systemctl restart scoreboard-timer
+sudo systemctl restart scoreboard-api.service
+sudo systemctl restart scoreboard-timer.service
 sudo systemctl restart scoreboard-timer.timer
-sudo systemctl restart nginx
+sudo systemctl restart nginx.service

--- a/deployment/centos/deploy.sh
+++ b/deployment/centos/deploy.sh
@@ -1,7 +1,15 @@
 #!/bin/bash -e
 
-# change this to the current semver tag, e.g. v1.8.0
-GIT_TAG=master
+# deploy scoreboard to a centos environment
+
+# usage: 
+#   deploy.sh {tag or branch}
+#
+# example:
+#   deploy.sh v1.8.0
+#
+
+GIT_TAG=${1:-master}
 
 echo "using git tag or branch: ${GIT_TAG}"
 echo

--- a/deployment/centos/deploy.sh
+++ b/deployment/centos/deploy.sh
@@ -1,14 +1,21 @@
-#!/bin/sh
+#!/bin/bash -e
+
+# change this to the current semver tag, e.g. v1.8.0
+GIT_TAG=master
+
+echo "using git tag or branch: ${GIT_TAG}"
+echo
 
 cd ~
 rm -rf scoreboard
 git clone https://github.com/developmentseed/scoreboard.git
 cd scoreboard
-git checkout master
+git checkout ${GIT_TAG}
 
 # installation
 npm install
 npm run migrate
+npm run build
 
 # move to nginx folder
 cd ../..


### PR DESCRIPTION
Based on the last centos deployment, which we did manually, here are
some improvements:

- add missing `npm run build` step
- add variable and echo prompt for which git tag to use
- use `bash -e` so script will stop if something fails

Other than that, this deploy script looks fine and we should use it on
next deployment.

Closes #524 