### PR TITLE
Fix react state management bug.

### DIFF
--- a/pages/teams.js
+++ b/pages/teams.js
@@ -40,13 +40,9 @@ const Sidebar = ({ handleSearch }) => (
  * that exist on the platform
  */
 class Teams extends Component {
-  constructor () {
-    super()
-
-    this.state = {
-      teams: []
-    }
-
+  constructor (props) {
+    super(props)
+    this.state = { teams: [...props.teams.records] }
     this.handleSearch = this.handleSearch.bind(this)
   }
 


### PR DESCRIPTION
Fixes #511 

When the component is re-mounted, it does not know of the props
were are already stored in the redux state.

Copying the props in the component constructor fixes it.

This is a workaround, preferred solutions are documented here:

https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html