### PR TITLE
Add org id as an environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,6 +13,9 @@ OSM_CONSUMER_SECRET=****
 OSM_TEAMS_CLIENT_ID=****
 OSM_TEAMS_CLIENT_SECRET=****
 
+# OSM Teams organization ID for which teams are created
+OSM_TEAMS_ORG_ID=****
+
 ################################################################################
 #
 # Optional environment variables (the default value is shown)

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ callback URL would be `http://localhost:8181/auth/teams/accept` .
 
 The client id and client secret should be saved to your Scoreboard `.env` file.
 
+Scoreboard will work with a single organization at the moment. In osm-teams, record your organization's
+ID from the API and use the environment variable `OSM_TEAMS_ORG_ID` to have scoreboard read and write
+to the organization's teams.
+
 # Administrator Settings
 
 The Administrator Settings are found in the Admin user's dashboard, or

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -37,6 +37,7 @@ module.exports = {
   OSM_TEAMS_SERVICE_TOKEN_PATH: process.env.OSM_TEAMS_SERVICE_TOKEN_PATH || '/oauth2/token',
   OSM_TEAMS_SERVICE_AUTHZ_HOST: process.env.OSM_TEAMS_SERVICE_AUTHZ_HOST || 'http://localhost:4444',
   OSM_TEAMS_SERVICE_AUTHZ_PATH: process.env.OSM_TEAMS_SERVICE_AUTHZ_PATH || '/oauth2/auth',
+  OSM_TEAMS_ORG_ID: process.env.OSM_TEAMS_ORG_ID,
   OSM_TEAMS_CLIENT_ID: process.env.OSM_TEAMS_CLIENT_ID,
   OSM_TEAMS_CLIENT_SECRET: process.env.OSM_TEAMS_CLIENT_SECRET,
   PROJECT_NAME: process.env.PROJECT_NAME || 'OpenStreetMap',

--- a/api/src/services/teams.js
+++ b/api/src/services/teams.js
@@ -65,10 +65,6 @@ class OSMTeams {
     return rp(`${OSM_TEAMS_SERVICE}/api/organizations/${OSM_TEAMS_ORG_ID}/teams`)
   }
 
-  getTeamsByOsmId (id) {
-    return rp(`${OSM_TEAMS_SERVICE}/api/teams?osmId=${id}&organizationId=${OSM_TEAMS_ORG_ID}`)
-  }
-
   async createTeam (body) {
     var options = await this.addAuthorization({
       method: 'POST',

--- a/api/src/services/teams.js
+++ b/api/src/services/teams.js
@@ -2,7 +2,7 @@ const rp = require('request-promise-native')
 const sampleTeams = require('../fixtures/teams.json')
 const { getToken, storeToken } = require('../models/teams-access-tokens')
 const { teamServiceCredentials } = require('../passport')
-const { OSM_TEAMS_SERVICE } = require('../config')
+const { OSM_TEAMS_SERVICE, OSM_TEAMS_ORG_ID } = require('../config')
 
 /**
  * Methods to grab data from OSM Teams
@@ -60,19 +60,19 @@ class OSMTeams {
    */
   getTeams (id) {
     if (id) {
-      return rp(`${OSM_TEAMS_SERVICE}/api/teams?osmId=${id}`)
+      return rp(`${OSM_TEAMS_SERVICE}/api/teams?osmId=${id}&organizationId=${OSM_TEAMS_ORG_ID}`)
     }
-    return rp(`${OSM_TEAMS_SERVICE}/api/teams`)
+    return rp(`${OSM_TEAMS_SERVICE}/api/organizations/${OSM_TEAMS_ORG_ID}/teams`)
   }
 
   getTeamsByOsmId (id) {
-    return rp(`${OSM_TEAMS_SERVICE}/api/teams?osmId=${id}`)
+    return rp(`${OSM_TEAMS_SERVICE}/api/teams?osmId=${id}&organizationId=${OSM_TEAMS_ORG_ID}`)
   }
 
   async createTeam (body) {
     var options = await this.addAuthorization({
       method: 'POST',
-      uri: `${OSM_TEAMS_SERVICE}/api/teams`,
+      uri: `${OSM_TEAMS_SERVICE}/api/organizations/${OSM_TEAMS_ORG_ID}/teams`,
       body,
       json: true
     })


### PR DESCRIPTION
Rough draft to add orgs to scoreboard. This would make Scoreboard work with only 1 organization on osm-teams, and should work for our short-term goals. 