### PR TITLE
Fix Next.js deprecation warning; Fix IDE warning.

### DIFF
--- a/components/dashboard/DashboardBlurb.js
+++ b/components/dashboard/DashboardBlurb.js
@@ -34,7 +34,7 @@ export default function Blurb ({
     countryWord = 'country'
   }
   if (isNaN(firstYearEdited)) {
-    return <h2 className='header--small width--shortened list--block'>{(username) ? `${username} has` : 'You have'} not made any mapping edits in {project} yet. Explore <Link href='/campaigns'>active campaigns</Link> to get started!</h2>
+    return <h2 className='header--small width--shortened list--block'>{(username) ? `${username} has` : 'You have'} not made any mapping edits in {project} yet. Explore <Link href={'/campaigns'}><a>active campaigns</a></Link> to get started!</h2>
   } else {
     return <h2 className='header--small width--shortened list--block'>
       Since <mark>{firstYearEdited}</mark>, {sentence} <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_railways_add + km_railways_mod)}</mark> of railways, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways in <mark>{country_list.length}</mark> <mark>{countryWord}</mark>.


### PR DESCRIPTION
- Adding an `<a>` element suppresses the deprecation warning

   `Warning: You're using a string directly inside <Link>. This usage has been deprecated. Please add an <a> tag as child of <Link>`

- Changing the Link's href to a JS variable silences an IDE warning about "file not found".