### PR TITLE
Add page for team moderation

### DIFF
--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -52,6 +52,8 @@ router.post('/teams', teams.post)
 router.get('/teams/:id', teams.get)
 router.put('/teams/:id', teams.put)
 router.delete('/teams/:id', teams.del)
+router.put('/teams/:id/assignModerator/:osmId', teams.assignModerator)
+router.put('/teams/:id/removeModerator/:osmId', teams.removeModerator)
 
 // taskers routes
 router.get('/taskers', taskers.list)

--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -138,6 +138,48 @@ async function put (req, res) {
 }
 
 /**
+ * Teams addModerator route
+ * /teams/:id/addModerator/:osmId
+ *
+ *
+ * @param {Object} req - the request object
+ * @param {Object} res - the response object
+ * @returns {Promise} a response
+ */
+async function assignModerator (req, res) {
+  const { user } = req
+  const { id: teamId, osmId } = req.params
+  const teams = new OSMTeams(user.id)
+  try {
+    await teams.assignModerator(teamId, osmId)
+  } catch (err) {
+    console.error(err)
+    return res.boom.badRequest('Could not update team')
+  }
+}
+
+/**
+ * Teams removeModerator route
+ * /teams/:id/removeModerator/:osmId
+ *
+ *
+ * @param {Object} req - the request object
+ * @param {Object} res - the response object
+ * @returns {Promise} a response
+ */
+async function removeModerator (req, res) {
+  const { user } = req
+  const { id: teamId, osmId } = req.params
+  const teams = new OSMTeams(user.id)
+  try {
+    await teams.removeModerator(teamId, osmId)
+  } catch (err) {
+    console.error(err)
+    return res.boom.badRequest('Could not update team')
+  }
+}
+
+/**
  * Teams delete route
  * /teams/:id
  *
@@ -165,5 +207,7 @@ module.exports = {
   post,
   get,
   put,
-  del
+  del,
+  assignModerator,
+  removeModerator
 }

--- a/api/src/services/teams.js
+++ b/api/src/services/teams.js
@@ -107,6 +107,24 @@ class OSMTeams {
     })
     return rp(options)
   }
+
+  async assignModerator (id, osmId) {
+    var options = await this.addAuthorization({
+      method: 'PUT',
+      uri: `${OSM_TEAMS_SERVICE}/api/teams/${id}/assignModerator/${osmId}`,
+      json: true
+    })
+    return rp(options)
+  }
+
+  async removeModerator (id, osmId) {
+    var options = await this.addAuthorization({
+      method: 'PUT',
+      uri: `${OSM_TEAMS_SERVICE}/api/teams/${id}/removeModerator/${osmId}`,
+      json: true
+    })
+    return rp(options)
+  }
 }
 
 class FakeOSMTeams {

--- a/lib/store/actions/teams.js
+++ b/lib/store/actions/teams.js
@@ -90,5 +90,62 @@ export default store => ({
     }).catch((error) => {
       store.setState({ notification: { type: 'error', message: error.message } })
     })
+  },
+
+  assignModerator (state, params) {
+    const { id, osmId } = params
+
+    return fetch(`/api/teams/${id}/assignModerator/${osmId}`, {
+      method: 'PUT',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      }
+    }).then(res => {
+      if (res.status === 200) {
+        return res.text()
+      } else {
+        console.log(res.error)
+        throw new Error('Failed to update team')
+      }
+    }).then(fetch(`/api/teams/${id}`)
+      .then(async res => {
+        const team = await res.json()
+        store.setState({ team })
+      }))
+      .then(() => {
+        store.setState({ notification: { type: 'success', message: 'Moderator added successfully' } })
+      }).catch((error) => {
+        store.setState({ notification: { type: 'error', message: error.message } })
+      })
+  },
+
+  removeModerator (state, params) {
+    const { id, osmId } = params
+
+    return fetch(`/api/teams/${id}/removeModerator/${osmId}`, {
+      method: 'PUT',
+      credentials: 'include',
+      body: JSON.stringify(params),
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8'
+      }
+    }).then(res => {
+      if (res.status === 200) {
+        return res.text()
+      } else {
+        console.log(res.error)
+        throw new Error('Failed to update team')
+      }
+    }).then(fetch(`/api/teams/${id}`)
+      .then(async res => {
+        const team = await res.json()
+        store.setState({ team })
+      }))
+      .then(() => {
+        store.setState({ notification: { type: 'success', message: 'Moderator removed successfully' } })
+      }).catch((error) => {
+        store.setState({ notification: { type: 'error', message: error.message } })
+      })
   }
 })

--- a/pages/edit-moderators.js
+++ b/pages/edit-moderators.js
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react'
+import NotLoggedIn from '../components/NotLoggedIn'
+import { LoadingState } from '../components/common/LoadingState'
+import { connect } from 'unistore/react'
+import { actions } from '../lib/store'
+import Table from '../components/common/Table'
+import { includes, prop } from 'ramda'
+
+const tableSchema = {
+  'headers': {
+    'name': { type: 'string', accessor: 'full_name' },
+    'role': { type: 'string', accessor: 'role' },
+    'button': { type: 'string', accessor: 'button' }
+  },
+  columnOrder: ['name', 'role', 'button'],
+  displaysTooltip: []
+}
+
+export function EditTeamModerators (props) {
+  const [loading, setLoading] = useState(true)
+
+  // On load get the user
+  useEffect(() => {
+    props.getAuthenticatedUser()
+      .then(() => props.getTeam(props.id))
+      .then(() => setLoading(false))
+  }, [])
+
+  if (loading || !props.team) {
+    return <LoadingState />
+  }
+  const { authenticatedUser } = props
+
+  if (!authenticatedUser.loggedIn) {
+    return <NotLoggedIn />
+  }
+
+  const { users, moderators, id: teamId } = props.team
+  const moderatorIds = moderators.map(prop('osm_id'))
+
+  const rows = users.map(u => {
+    const isUserModerator = includes(u.osm_id, moderatorIds)
+    return {
+      full_name: u.full_name,
+      role: isUserModerator ? 'moderator' : 'member',
+      button: isUserModerator
+        ? <button style={{ 'padding': '5px' }} className='button' onClick={() => props.removeModerator({ id: teamId, osmId: u.osm_id })} >Remove Moderator</button>
+        : <button style={{ 'padding': '5px' }} className='button' onClick={() => props.assignModerator({ id: teamId, osmId: u.osm_id })} >Add Moderator</button>
+    }
+  })
+
+  return (
+    <div className='admin'>
+      <section>
+        <div className='row widget-container'>
+          <div className='widget-25'>
+            <h2 className='header--large'>Edit team</h2>
+          </div>
+          <div className='widget-75'>
+            <div>
+              <h1 className='header--xlarge'>Edit Moderators</h1>
+              <div className='widget'>
+                <Table tableSchema={tableSchema} data={rows} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+const Page = connect(['authenticatedUser', 'teams', 'team'], actions)(EditTeamModerators)
+
+Page.getInitialProps = async ({ query }) => {
+  const { id } = query
+  return { id }
+}
+
+export default Page

--- a/pages/edit-moderators.js
+++ b/pages/edit-moderators.js
@@ -4,6 +4,7 @@ import { LoadingState } from '../components/common/LoadingState'
 import { connect } from 'unistore/react'
 import { actions } from '../lib/store'
 import Table from '../components/common/Table'
+import Link from '../components/Link'
 import { includes, prop } from 'ramda'
 
 const tableSchema = {
@@ -35,7 +36,7 @@ export function EditTeamModerators (props) {
     return <NotLoggedIn />
   }
 
-  const { users, moderators, id: teamId } = props.team
+  const { users, moderators, id: teamId, name } = props.team
   const moderatorIds = moderators.map(prop('osm_id'))
 
   const rows = users.map(u => {
@@ -44,7 +45,7 @@ export function EditTeamModerators (props) {
       full_name: u.full_name,
       role: isUserModerator ? 'moderator' : 'member',
       button: isUserModerator
-        ? <button style={{ 'padding': '5px' }} className='button' onClick={() => props.removeModerator({ id: teamId, osmId: u.osm_id })} >Remove Moderator</button>
+        ? <button style={{ 'padding': '5px' }} className='button button--destroy' onClick={() => props.removeModerator({ id: teamId, osmId: u.osm_id })} >Remove Moderator</button>
         : <button style={{ 'padding': '5px' }} className='button' onClick={() => props.assignModerator({ id: teamId, osmId: u.osm_id })} >Add Moderator</button>
     }
   })
@@ -55,10 +56,26 @@ export function EditTeamModerators (props) {
         <div className='row widget-container'>
           <div className='widget-25'>
             <h2 className='header--large'>Edit team</h2>
+            <ul className='admin-sidebar-links'>
+              <li>
+                <Link href={`/teams/${teamId}`}>
+                  <a className='link--large'>
+                    Team Page
+                  </a>
+                </Link>
+              </li>
+              <li>
+                <Link href={`/teams/${teamId}/edit-details`}>
+                  <a className='link--large'>
+                    Edit team details
+                  </a>
+                </Link>
+              </li>
+            </ul>
           </div>
           <div className='widget-75'>
             <div>
-              <h1 className='header--xlarge'>Edit Moderators</h1>
+              <h1 className='header--xlarge'>Edit Moderators for {name}</h1>
               <div className='widget'>
                 <Table tableSchema={tableSchema} data={rows} />
               </div>

--- a/pages/edit-team-details.js
+++ b/pages/edit-team-details.js
@@ -107,7 +107,7 @@ export function EditTeam (props) {
   useEffect(() => {
     props.getAuthenticatedUser()
       .then(() => setLoading(false))
-  })
+  }, [])
 
   if (loading) {
     return <LoadingState />

--- a/pages/edit-team-details.js
+++ b/pages/edit-team-details.js
@@ -8,6 +8,7 @@ import fetch from '../lib/utils/api'
 import TeamDetailsForm from '../components/teams/TeamDetailsForm'
 import TeamMembersForm from '../components/teams/TeamMembersForm'
 import TeamCampaignsForm from '../components/teams/TeamCampaignsForm'
+import Link from '../components/Link'
 import Router from '../lib/router'
 
 function DestroyButton ({ onDestroy }) {
@@ -124,10 +125,26 @@ export function EditTeam (props) {
         <div className='row widget-container'>
           <div className='widget-25'>
             <h2 className='header--large'>Edit a team</h2>
+            <ul className='admin-sidebar-links'>
+              <li>
+                <Link href={`/teams/${props.id}`}>
+                  <a className='link--large'>
+                    Team Page
+                  </a>
+                </Link>
+              </li>
+              <li>
+                <Link href={`/teams/${props.id}/edit-moderators`}>
+                  <a className='link--large'>
+                    Edit team moderators
+                  </a>
+                </Link>
+              </li>
+            </ul>
           </div>
           <div className='widget-75'>
             <div>
-              <h1 className='header--xlarge'>Details</h1>
+              <h1 className='header--xlarge'>Details for {props.data.name}</h1>
             </div>
             { props.data
               ? <TeamDetailsForm

--- a/server.js
+++ b/server.js
@@ -52,14 +52,9 @@ app.prepare()
       app.render(req, res, '/edit-team-details', { id })
     })
 
-    api.get('/teams/:id/edit-members', (req, res) => {
+    api.get('/teams/:id/edit-moderators', (req, res) => {
       const { id } = req.params
-      app.render(req, res, '/edit-team-members', { id })
-    })
-
-    api.get('/teams/:id/edit-campaigns', (req, res) => {
-      const { id } = req.params
-      app.render(req, res, '/edit-team-campaigns', { id })
+      app.render(req, res, '/edit-moderators', { id })
     })
 
     api.get('/campaigns/:id', (req, res) => {


### PR DESCRIPTION
This adds a new page at `teams/:teamId/edit-moderators` that allows the current moderator to modify the moderator list. I added it as a new page because it is interactive rather than being done through a form. We should link to it from either the team edit page, or from the single team page.

This PR is based on `feature/edit-team`, so if we merge that in first we should change the PR target. 