### PR TITLE
Fix session timeouts

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -43,25 +43,15 @@ swaggerDocument.info.version = pckg.version
  */
 
 let sessionConfig = {
+  name: 'scoreboard',
   secret: SESSION_SECRET,
   resave: false,
-  saveUninitialized: true,
-  expires: new Date(Date.now() + (30 * 86400 * 1000))
+  saveUninitialized: false,
+  unset: 'destroy',
+  store: new KnexSessionStore({ knex: db }),
+  cookie: { maxAge: 30 * 86400 * 1000 } // 1 month cookies
 }
 
-if (NODE_ENV === 'production') {
-  const store = new KnexSessionStore({
-    knex: db
-  })
-
-  Object.assign(sessionConfig, {
-    secret: SESSION_SECRET,
-    cookie: {
-      expires: new Date(Date.now() + (30 * 86400 * 1000))
-    },
-    store: store
-  })
-}
 app.use(bodyParser.json())
 app.use(compression())
 app.use(boom())

--- a/api/src/passport.js
+++ b/api/src/passport.js
@@ -172,8 +172,13 @@ router.get('/userinfo', (req, res) => {
  * Logout
  */
 router.get('/logout', (req, res) => {
-  req.logout()
-  res.redirect(APP_URL_FINAL)
+  req.session.destroy(function (err) {
+    req.session = null
+    if (err) {
+      console.error(err)
+    }
+    res.redirect(APP_URL_FINAL)
+  })
 })
 
 /**


### PR DESCRIPTION
Closes #347 by simplifying the session and setting recommended values. I changed setUninitialized to false so that aren't "empty" sessions that are created in case that's where the API was looking for tokens. I also modified the "expires" key to a "maxAge" key (which is recommended).