### PR TITLE
Propagate loggedIn prop to teams page

### DIFF
--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -17,9 +17,16 @@ async function list (req, res) {
   try {
     const { user: { id: osmId = null } = {} } = req
     const teamService = new OSMTeams(osmId)
-    const teams = JSON.parse(await teamService.getTeams())
-    const canCreate = await teamService.canCreateTeam()
-    return res.send({ teams, canCreate })
+    const teams = await teamService.getTeams()
+    let canCreate = false
+    try {
+      canCreate = await teamService.canCreateTeam()
+    } catch (e) {
+      if (e.message !== 'No token for user') {
+        console.error(e)
+      }
+    }
+    return res.send({ teams: JSON.parse(teams), canCreate })
   } catch (err) {
     console.error(err)
     return res.boom.badRequest('Could not retrieve teams list')

--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -22,6 +22,12 @@ async function list (req, res) {
     try {
       canCreate = await teamService.canCreateTeam()
     } catch (e) {
+      /**
+       * If there is no osm-teams token for user, we catch the error and fail silently
+       * by letting canCreate = false (default). In other cases, we're interested in the error so
+       * we log it.
+       *
+       */
       if (e.message !== 'No token for user') {
         console.error(e)
       }

--- a/components/TeamConnectBanner.js
+++ b/components/TeamConnectBanner.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react'
+import join from 'url-join'
+import { APP_URL_PREFIX } from '../api/src/config'
 import Link from './Link'
 
 export default class TeamsConnectBanner extends Component {
@@ -10,15 +12,15 @@ export default class TeamsConnectBanner extends Component {
           <p>Connect the Teams application with Scoreboard to:</p>
           <div className='widget-container'>
             <div>
-              <img src='../../static/teams-icon-private.svg' />
+              <img src={join(APP_URL_PREFIX, '/static/teams-icon-private.svg')} />
               <h3 className='link--large'>View your private teams</h3>
             </div>
             <div>
-              <img src='../../static/teams-icon-new.svg' />
+              <img src={join(APP_URL_PREFIX, '/static/teams-icon-new.svg')} />
               <h3 className='link--large'>Create new teams</h3>
             </div>
             <div>
-              <img src='../../static/teams-icon-edit.svg' />
+              <img src={join(APP_URL_PREFIX, '/static/teams-icon-edit.svg')} />
               <h3 className='link--large'>Edit and Moderate teams</h3>
             </div>
           </div>

--- a/lib/store/index.js
+++ b/lib/store/index.js
@@ -28,7 +28,7 @@ export const InitialState = {
   },
   tasker: null,
   taskers: [],
-  teams: { records: [] },
+  teams: { records: [], canCreate: false },
   exclusionList: null,
   team: null,
   user: null,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -212,7 +212,9 @@ class Layout extends React.Component {
             </nav>
           </div>
         </header>
-        {children}
+        {
+          React.cloneElement(children, { loggedIn })
+        }
         <Footer loggedIn={loggedIn} />
       </div>
     )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -213,7 +213,7 @@ class Layout extends React.Component {
           </div>
         </header>
         {
-          React.cloneElement(children, { loggedIn })
+          React.cloneElement(children, { loggedIn, authenticatedUser })
         }
         <Footer loggedIn={loggedIn} />
       </div>

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -211,7 +211,7 @@ class Teams extends Component {
     }
 
     const { teams, canCreate, user, searchText, onlyMemberTeams, onlyModeratedTeams } = this.state
-    const loggedIn = this.props // comes from page props
+    const { loggedIn } = this.props // comes from page props
     const activatedTeams = pathOr(false, ['account', 'activatedTeams'], user)
     return (
       <div className='Teams'>

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -118,7 +118,7 @@ class Teams extends Component {
   componentDidUpdate (prevProps) {
     const { teams: prevTeams } = prevProps
     const { teams, authenticatedUser } = this.props
-    if (prevTeams.records.length !== teams.records.length) {
+    if ((prevTeams.records.length !== teams.records.length) || (prevTeams.canCreate !== teams.canCreate)) {
       this.setState({
         user: authenticatedUser,
         teams: teams.records,

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -95,15 +95,13 @@ const Sidebar = ({
 class Teams extends Component {
   constructor (props) {
     super(props)
-    const { authenticatedUser } = props
     this.state = {
       loading: true,
       teams: [...props.teams.records],
       canCreate: props.teams.canCreate,
       searchText: '',
       onlyMemberTeams: false,
-      onlyModeratedTeams: false,
-      user: { ...authenticatedUser }
+      onlyModeratedTeams: false
     }
     this.handleSearch = this.handleSearch.bind(this)
     this.handleOnlyMemberTeamsToggle = this.handleOnlyMemberTeamsToggle.bind(this)
@@ -112,10 +110,9 @@ class Teams extends Component {
   }
 
   async componentDidMount () {
-    await this.props.getAuthenticatedUser().then(() => {
+    await this.props.getAllTeams().then(() => {
       this.setState({ loading: false })
     })
-    await this.props.getAllTeams()
   }
 
   componentDidUpdate (prevProps) {
@@ -201,7 +198,7 @@ class Teams extends Component {
   }
 
   render () {
-    if (this.state.loading || !this.state.user) {
+    if (this.state.loading) {
       return (
         <div>
           <header className='header--internal--green header--page' style={{ paddingBottom: '8rem' }} />
@@ -210,9 +207,9 @@ class Teams extends Component {
       )
     }
 
-    const { teams, canCreate, user, searchText, onlyMemberTeams, onlyModeratedTeams } = this.state
-    const { loggedIn } = this.props // comes from page props
-    const activatedTeams = pathOr(false, ['account', 'activatedTeams'], user)
+    const { teams, canCreate, searchText, onlyMemberTeams, onlyModeratedTeams } = this.state
+    const { loggedIn, authenticatedUser } = this.props // comes from page props
+    const activatedTeams = pathOr(false, ['account', 'activatedTeams'], authenticatedUser)
     return (
       <div className='Teams'>
         <header className='header--internal--green header--page'>
@@ -242,7 +239,7 @@ class Teams extends Component {
         <section>
           <div className='row widget-container'>
             <Sidebar
-              user={user}
+              user={authenticatedUser}
               searchText={searchText}
               onlyMemberTeams={onlyMemberTeams}
               onlyModeratedTeams={onlyModeratedTeams}

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -211,7 +211,7 @@ class Teams extends Component {
     }
 
     const { teams, canCreate, user, searchText, onlyMemberTeams, onlyModeratedTeams } = this.state
-    const loggedIn = pathOr(false, ['loggedIn'], user)
+    const loggedIn = this.props // comes from page props
     const activatedTeams = pathOr(false, ['account', 'activatedTeams'], user)
     return (
       <div className='Teams'>


### PR DESCRIPTION
This propagates the loggedIn prop that is created in `_app.js` for the navbar and header to all pages. Ideally, we would also do this for the authenticated user props and attach it to all page props but that's a larger refactor. 

I've also fixed static links in the banner, and an error that can happen in the state when the user is logged in but there is still no token.