### PR TITLE
Fix pagination bug in Teams Edit

### DIFF
--- a/components/teams/TeamCampaignsForm.js
+++ b/components/teams/TeamCampaignsForm.js
@@ -124,7 +124,7 @@ function CampaignSearch (props) {
             itemsCountPerPage={10}
             totalItemsCount={total}
             pageRangeDisplayed={5}
-            onChange={no => props.adminTeamCampaignsSearch(no || 1)}
+            onChange={no => props.adminTeamCampaignsPageChange(no || 1)}
           />
         </div>
       </section>

--- a/components/teams/TeamMembersForm.js
+++ b/components/teams/TeamMembersForm.js
@@ -37,7 +37,7 @@ function EditMembersForm (props) {
   }, [])
 
   const { page } = props.adminTeamMemberFilters
-  const { stats: { total, records } } = props.adminTeamMemberSearchResults
+  const { stats: { subTotal, records } } = props.adminTeamMemberSearchResults
 
   if (!records) return <div>Error loading</div>
 
@@ -71,8 +71,8 @@ function EditMembersForm (props) {
           <Table tableSchema={tableSchema} data={searchUsers} />
           <Pagination
             activePage={page}
-            itemsCountPerPage={10}
-            totalItemsCount={total}
+            itemsCountPerPage={25}
+            totalItemsCount={subTotal}
             pageRangeDisplayed={5}
             onChange={number => props.adminTeamMemberPageChange(number || 1)}
           />


### PR DESCRIPTION
* Campaigns Pagination bug was calling wrong prop method
* Users Pagination was using the wrong total users and number of
users displayed per page

Closes #570 
