### PR TITLE
Fix filters on teams index page.

### DIFF
--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -1,7 +1,7 @@
 const OSMTeams = require('../services/teams')
 const OSMesa = require('../services/osmesa')
 const db = require('../db/connection')
-const { difference } = require('ramda')
+const { difference, pathOr } = require('ramda')
 const getOsmesaLastRefreshed = require('../utils/osmesaStatus.js')
 
 /**
@@ -15,7 +15,7 @@ const getOsmesaLastRefreshed = require('../utils/osmesaStatus.js')
  */
 async function list (req, res) {
   try {
-    const { user: { id: osmId = null } = {} } = req
+    const osmId = pathOr(null, ['user', 'id'], req)
     const teamService = new OSMTeams(osmId)
     const teams = await teamService.getTeams()
     let canCreate = false

--- a/pages/teams.js
+++ b/pages/teams.js
@@ -150,8 +150,8 @@ class Teams extends Component {
   }
 
   handleFilters ({ searchText, onlyModeratedTeams, onlyMemberTeams }) {
-    const { user: { account: { id: osmId } = {} } = {} } = this.state
     let { teams: { records: teams } } = this.props
+    const osmId = pathOr(null, ['user', 'account', 'id'], this.state)
     if (searchText) {
       const rgx = new RegExp(searchText, 'ig')
       teams = teams.filter(record => rgx.test(record.name) || rgx.test(record.bio) || rgx.test(record.hashtag))


### PR DESCRIPTION
* Root cause seems to be problems transpiling default values in
  destructuring objects.  Changing to use Ramda pathOr fixes it.

Fixes #571 

### testing notes:

test in a production build and/or on staging server:

`yarn build && yarn start`