### PR TITLE
Maproulette campaign data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs-build
 node_modules
 node_modules.nosync
 .idea
+api/tests/tapes

--- a/api/src/db/seeds/development/settings.js
+++ b/api/src/db/seeds/development/settings.js
@@ -2,6 +2,7 @@ const { cache } = require('../../../config')
 const { put } = require('../../../models/settings')
 
 const settings = {
+  // default
   'osmesa-db': 'postgres://postgres@localhost:5434/postgres'
 }
 

--- a/api/src/db/seeds/development/users.js
+++ b/api/src/db/seeds/development/users.js
@@ -1,4 +1,7 @@
 const usersClock = require('../../../users_clock')
+const limit = require('p-limit')(100)
+const rp = require('request-promise-native')
+const { merge } = require('ramda')
 
 const { cache } = require('../../../config')
 
@@ -10,6 +13,70 @@ exports.seed = (knex) => knex('users').del() // delete entries
     })
 
     const users = await osmesaDB('users').select('id as osm_id', 'name as full_name')
-    return knex('users').insert(users)
+    await knex('users').insert(users)
+
+    //for dev purposes, load MR users from project leader boards
+    return getMrUsers(knex)
+
   })
   .then(usersClock)
+
+
+
+/*
+ * These functions load in users from MR Challenge leaderboards and add them to the scoreboard database 
+ */
+const getMrUsers = async knex => {
+  const [{ id, url }] = await knex('taskers').where('type', 'mr').select()
+
+  const mrChallenges = await knex('campaigns').where('tasker_id', id).select()
+  return getAndUpdateUsers(knex, mrChallenges, url)
+}
+
+async function getAndUpdateUsers (db, challenges, url) {
+  let qs = {
+    limit: 25,
+    monthDuration: -1,
+    challengeIds: challenges.map(c => c.tm_id).join(',')
+  }
+  const usersResp = await rp({
+    uri: `${url}/api/v2/data/user/leaderboard`,
+    qs,
+    headers: { 'Accept-Language': 'en-US,en;q=0.9' }
+  })
+  const mrUsers = JSON.parse(usersResp)
+
+
+  const proms = mrUsers.map(curUser => limit(async () => {
+    const resp = await rp({
+      uri: `${url}/api/v2/user/${curUser.userId}/public`,
+      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
+    })
+    const userData = JSON.parse(resp)
+    const user = {
+      osm_id: userData.osmProfile.id,
+      full_name: userData.osmProfile.displayName,
+      user_info: {
+        display_name: userData.osmProfile.displayName,
+        full_name: userData.osmProfile.displayName
+      }
+
+    }
+
+    return db('users')
+      .where({ 'osm_id': user.osm_id, 'full_name': user.full_name })
+      .then(rows => {
+        try {
+          if (rows.length === 0) {
+            return db('users').insert(merge(user, { updated_at: db.fn.now(), created_at: db.fn.now() }))
+          } else {
+            return db('users').where('osm_id', user.osm_id).update(merge(user, { updated_at: db.fn.now() }))
+          }
+        } catch (err) {
+          console.log(user)
+        }
+      })
+  }))
+
+  return Promise.all(proms)
+}

--- a/api/src/db/seeds/development/users.js
+++ b/api/src/db/seeds/development/users.js
@@ -1,7 +1,4 @@
 const usersClock = require('../../../users_clock')
-const limit = require('p-limit')(100)
-const rp = require('request-promise-native')
-const { merge } = require('ramda')
 
 const { cache } = require('../../../config')
 
@@ -19,67 +16,7 @@ exports.seed = (knex) => knex('users').del() // delete entries
     users.forEach(u => {
       seen.set(u.osm_id, u)
     })
-    await knex('users').insert([...seen.values()])
 
-    // for dev purposes, load MR users from project leader boards
-    return getMrUsers(knex)
+    return knex('users').insert([...seen.values()])
   })
   .then(usersClock)
-
-/*
- * These functions load in users from MR Challenge leaderboards and add them to the scoreboard database
- */
-const getMrUsers = async knex => {
-  const [{ id, url }] = await knex('taskers').where('type', 'mr').select()
-
-  const mrChallenges = await knex('campaigns').where('tasker_id', id).select()
-  return getAndUpdateUsers(knex, mrChallenges, url)
-}
-
-async function getAndUpdateUsers (db, challenges, url) {
-  let qs = {
-    limit: 25,
-    monthDuration: -1,
-    challengeIds: challenges.map(c => c.tm_id).join(',')
-  }
-  const usersResp = await rp({
-    uri: `${url}/api/v2/data/user/leaderboard`,
-    qs,
-    headers: { 'Accept-Language': 'en-US,en;q=0.9' }
-  })
-  const mrUsers = JSON.parse(usersResp)
-
-  const proms = mrUsers.map(curUser => limit(async () => {
-    const resp = await rp({
-      uri: `${url}/api/v2/user/${curUser.userId}/public`,
-      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
-    })
-    const userData = JSON.parse(resp)
-    const user = {
-      osm_id: userData.osmProfile.id,
-      full_name: userData.osmProfile.displayName,
-      user_info: {
-        display_name: userData.osmProfile.displayName,
-        full_name: userData.osmProfile.displayName
-      }
-
-    }
-
-    return db('users')
-      .where({ 'osm_id': user.osm_id, 'full_name': user.full_name })
-      .then(rows => {
-        try {
-          if (rows.length === 0) {
-            console.log(user.osm_id)
-            return db('users').insert(merge(user, { updated_at: db.fn.now(), created_at: db.fn.now() }))
-          } else {
-            return db('users').where('osm_id', user.osm_id).update(merge(user, { updated_at: db.fn.now() }))
-          }
-        } catch (err) {
-          console.log(user)
-        }
-      })
-  }))
-
-  return Promise.all(proms)
-}

--- a/api/src/db/seeds/development/users.js
+++ b/api/src/db/seeds/development/users.js
@@ -13,10 +13,10 @@ exports.seed = (knex) => knex('users').del() // delete entries
     })
 
     const users = await osmesaDB('users').select('id as osm_id', 'name as full_name')
-    
+
     // Make sure all users are unique
     const seen = new Map()
-    users.forEach( u =>{
+    users.forEach(u => {
       seen.set(u.osm_id, u)
     })
     await knex('users').insert([...seen.values()])

--- a/api/src/routes/campaign.js
+++ b/api/src/routes/campaign.js
@@ -108,9 +108,9 @@ async function loadOsMesaStats (response) {
     statsType: 'osmesa',
     schema: osmesaUserStatSchema,
     data: osmesaResponse.users,
-    extent_uri: osmesaResponse.extent_uri,
-    tag: osmesaResponse.tag
+    ...osmesaResponse
   }
+  delete stats.users
   const userIds = stats.data.map(user => user.uid)
   const userCountries = await db('users').select(['osm_id', 'country']).whereIn('osm_id', userIds)
 

--- a/api/src/routes/campaign.js
+++ b/api/src/routes/campaign.js
@@ -138,9 +138,13 @@ function populatePanelContent (tmData, tables, type) {
         { label: 'Avg Time Spent', value: `${parseInt(data.avgTimeSpent, 10)}` }
       ]
     case 'tm3':
+      const stats = tables.find(t => t.statsType === 'osmesa')
       return [
         { label: 'Mapped', value: `${parseInt(tmData.done, 10)}%` },
-        { label: 'Validated', value: `${parseInt(tmData.validated, 10)}%` }
+        { label: 'Validated', value: `${parseInt(tmData.validated, 10)}%` },
+        { label: 'Participants', value: stats.data.length },
+        { label: 'Total Edits', value: stats.editCounts }
+
       ]
     default:
       return []

--- a/api/src/routes/campaign.js
+++ b/api/src/routes/campaign.js
@@ -64,7 +64,8 @@ module.exports = async (req, res) => {
       data: [actions],
       success: true,
       statsType: 'maproulette-challenge',
-      schema: maprouletteChallengeSchema
+      schema: maprouletteChallengeSchema,
+      sortable: false
     }
     response.tables.push(stats)
   } catch (err) {
@@ -131,7 +132,7 @@ async function loadOsMesaStats (response) {
 function populatePanelContent (tmData, tables, type) {
   switch (type) {
     case 'mr':
-      const [data] = tables.find(t => t.statsType === 'maproulette-challenge').data;
+      const [data] = tables.find(t => t.statsType === 'maproulette-challenge').data
       return [
         { label: 'Tasks', value: `${parseInt(data.total - data.available, 10)}` },
         { label: 'Remaining', value: `${parseInt(100 - tmData.done, 10)}%` },

--- a/api/src/routes/campaign.js
+++ b/api/src/routes/campaign.js
@@ -99,6 +99,8 @@ module.exports = async (req, res) => {
     }
   }
 
+  response['panelContent'] = populatePanelContent(response.meta, response.tables, tm.type)
+
   return res.send(response)
 }
 
@@ -124,4 +126,23 @@ async function loadOsMesaStats (response) {
 
   response.tables.push(stats)
   return Promise.all([osmesaResponse, userCountries])
+}
+
+function populatePanelContent (tmData, tables, type) {
+  switch (type) {
+    case 'mr':
+      const [data] = tables.find(t => t.statsType === 'maproulette-challenge').data;
+      return [
+        { label: 'Tasks', value: `${parseInt(data.total - data.available, 10)}` },
+        { label: 'Remaining', value: `${parseInt(100 - tmData.done, 10)}%` },
+        { label: 'Avg Time Spent', value: `${parseInt(data.avgTimeSpent, 10)}` }
+      ]
+    case 'tm3':
+      return [
+        { label: 'Mapped', value: `${parseInt(tmData.done, 10)}%` },
+        { label: 'Validated', value: `${parseInt(tmData.validated, 10)}%` }
+      ]
+    default:
+      return []
+  }
 }

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -80,7 +80,14 @@ class MapRouletteAPI {
     })
   }
 
-  async getProjectStats (id) {
+  getProjectStats (id) {
+    return rp({
+      uri: `${this.api_url}/api/v2/data/challenge/${id}`,
+      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
+    })
+  }
+
+  async getProjectUserStats (id) {
     const qs = {
       monthDuration: -1,
       challengeIds: id,

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -1,6 +1,5 @@
 const rp = require('request-promise-native')
 const limit = require('p-limit')(5)
-const { merge } = require('ramda')
 
 // const extractCampaignHashtag = require('../../utils/extractCampaignHashtag')
 
@@ -74,44 +73,6 @@ class MapRouletteAPI {
     return challenges
   }
 
-  async getAndUpdateUsers (db, challenges) {
-    let qs = {
-      limit: 10,
-      monthDuration: -1,
-      challengeIds: challenges.map(c => c.tm_id).join(',')
-    }
-    const usersResp = await rp({
-      uri: `${this.api_url}/api/v2/data/user/leaderboard`,
-      qs,
-      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
-    })
-    const mrUsers = JSON.parse(usersResp)
-    const proms = mrUsers.map(curUser => limit(async () => {
-      const resp = await rp({
-        uri: `${this.api_url}/api/v2/user/${curUser.userId}/public`,
-        headers: { 'Accept-Language': 'en-US,en;q=0.9' }
-      })
-      const userData = JSON.parse(resp)
-      const user = {
-        osm_id: userData.osmProfile.id,
-        user_info: {
-          display_name: userData.osmProfile.displayName
-        }
-      }
-      return db('users')
-        .where('osm_id', user.osm_id)
-        .then(rows => {
-          if (rows.length === 0) {
-            console.log('inserting', user.osm_id)
-            return db('users').insert(merge(user, { updated_at: db.fn.now(), created_at: db.fn.now() }))
-          } else {
-            return db('users').where('osm_id', user.osm_id).update(merge(user, { updated_at: db.fn.now() }))
-          }
-        })
-    }))
-
-    return Promise.all(proms)
-  }
 
   getProject (id) {
     return rp({
@@ -183,8 +144,7 @@ class MapRouletteAPI {
         return db('campaigns').where('id', rows[0].id).update(obj)
       }
     }))
-
-    return Promise.all([...campaignProms, this.getAndUpdateUsers(db, dbObjects)])
+    return Promise.all(campaignProms)
   }
 }
 

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -168,6 +168,7 @@ class MapRouletteAPI {
       try {
         const [{ actions: data }] = JSON.parse(dataRes)
         obj.done = (1 - data.available / data.total) * 100
+        obj.validated = data.validated / data.total * 100
       } catch (e) {
         if (e instanceof TypeError) {
           console.error(`Challenge ${obj.tm_id} does not have available metadata`)

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -147,6 +147,7 @@ class MapRouletteAPI {
         geometry: challenge.bounding,
         // HARD CODED VALUES
         status: 'PUBLISHED',
+        // TODO Need to query this from MR api
         campaign_hashtag: 'test',
         validated: 0,
         done: 0 // placeholder value

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -104,7 +104,9 @@ class MapRouletteAPI {
         uid: user.userId,
         name: user.name,
         rank: user.rank,
-        score: user.score
+        score: user.score,
+        avgTimeSpent: user.avgTimeSpent,
+        completedTasks: user.completedTasks
       }
       return userObj
     })

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -111,7 +111,7 @@ class MapRouletteAPI {
 
     const campaignObj = {
       tag: id,
-      users,
+      data: users,
       success: true
     }
     return campaignObj

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -151,7 +151,7 @@ class MapRouletteAPI {
         status: 'PUBLISHED',
         // TODO Need to query this from MR api
         campaign_hashtag: 'test',
-        validated: 0,
+        validated: 0, // placeholder
         done: 0 // placeholder value
       }
     })

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -81,6 +81,37 @@ class MapRouletteAPI {
     })
   }
 
+  async getProjectStats (id) {
+    const qs = {
+      monthDuration: -1,
+      challengeIds: id,
+      limit: 20
+    }
+    const userData = await rp({
+      uri: `${this.api_url}/api/v2/data/user/leaderboard`,
+      qs,
+      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
+    })
+
+    const users = JSON.parse(userData).map(user => {
+      const userObj = {
+        uid: user.userId,
+        name: user.name,
+        rank: user.rank,
+        score: user.score
+      }
+      return userObj
+    })
+
+    const campaignObj = {
+      tag: id,
+      users,
+      success: true
+    }
+    return campaignObj 
+
+  }
+
   getProjectAoi (id) {
     return new Promise((resolve, reject) => {
       rp({

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -73,7 +73,6 @@ class MapRouletteAPI {
     return challenges
   }
 
-
   getProject (id) {
     return rp({
       uri: `${this.api_url}/api/v2/challenge/${id}`,
@@ -108,8 +107,7 @@ class MapRouletteAPI {
       users,
       success: true
     }
-    return campaignObj 
-
+    return campaignObj
   }
 
   getProjectAoi (id) {

--- a/api/src/users_clock.js
+++ b/api/src/users_clock.js
@@ -45,6 +45,7 @@ async function updateCountries (userID, countryEditList) {
  * @returns {Promise} a response
  */
 async function usersWorker () {
+  console.log('clock')
   try {
     const users = await db('users').select('id', 'osm_id') // Get all users
 

--- a/api/src/users_clock.js
+++ b/api/src/users_clock.js
@@ -45,7 +45,6 @@ async function updateCountries (userID, countryEditList) {
  * @returns {Promise} a response
  */
 async function usersWorker () {
-  console.log('clock')
   try {
     const users = await db('users').select('id', 'osm_id') // Get all users
 

--- a/api/src/utils/campaignTableSchema.js
+++ b/api/src/utils/campaignTableSchema.js
@@ -70,19 +70,24 @@ const maprouletteUserStatSchema = {
   'headers': {
     'name': { type: 'namelink', accessor: 'name' },
     'rank': { type: 'number', accessor: 'rank' },
-    'score': { type: 'number', accessor: 'score' }
+    'score': { type: 'number', accessor: 'score' },
+    'avgTimeSpent': { type: 'number', accessor: 'avgTimeSpent' },
+    'completedTasks': { type: 'number', accessor: 'completedTasks' }
   },
   columnOrder: [
-    'name',
     'rank',
-    'score'
+    'name',
+    'score',
+    'avgTimeSpent',
+    'completedTasks'
   ],
   'displaysTooltip': [
     'name',
     'rank',
-    'score'
+    'score',
+    'avgTimeSpent',
+    'completedTasks'
   ]
-
 }
 
 module.exports = {

--- a/api/src/utils/campaignTableSchema.js
+++ b/api/src/utils/campaignTableSchema.js
@@ -1,0 +1,97 @@
+const osmesaUserStatSchema = {
+  'headers': {
+    'name': { type: 'namelink', accessor: 'name' },
+    'country': { type: 'string', accessor: 'country' },
+    'roads': { type: 'number', accessor: 'km_roads_add_mod' },
+    'buildings': { type: 'number', accessor: 'buildings_add_mod' },
+    'poi': { type: 'number', accessor: 'poi_add_mod' },
+    'railways': { type: 'number', accessor: 'km_railways_add_mod' },
+    'coastlines': { type: 'number', accessor: 'km_coastlines_add_mod' },
+    'waterways': { type: 'number', accessor: 'km_waterways_add_mod' },
+    'changesets': { type: 'number', accessor: 'changeset_count' },
+    'edits': { type: 'number', accessor: 'edit_count' }
+  },
+  'columnOrder': [
+    'name',
+    'country',
+    'roads',
+    'buildings',
+    'poi',
+    'railways',
+    'coastlines',
+    'waterways',
+    'changesets',
+    'edits'
+  ],
+  'displaysTooltip': [
+    'name',
+    'buildings',
+    'poi',
+    'changesets',
+    'edits'
+  ]
+
+}
+const maprouletteChallengeSchema = {
+  'headers': {
+    'fixed': { type: 'number', accessor: 'fixed' },
+    'falsePositive': { type: 'number', accessor: 'falsePositive' },
+    'skipped': { type: 'number', accessor: 'skipped' },
+    'deleted': { type: 'number', accessor: 'deleted' },
+    'alreadyFixed': { type: 'number', accessor: 'alreadyFixed' },
+    'tooHard': { type: 'number', accessor: 'tooHard' },
+    'answered': { type: 'number', accessor: 'answered' },
+    'validated': { type: 'number', accessor: 'validated' },
+    'disabled': { type: 'number', accessor: 'disabled' },
+    'avgTimeSpent': { type: 'number', accessor: 'avgTimeSpent' }
+  },
+  columnOrder: [
+    'fixed',
+    'falsePositive',
+    'skipped',
+    'deleted',
+    'alreadyFixed',
+    'tooHard',
+    'answered',
+    'validated',
+    'disabled',
+    'avgTimeSpent'
+  ],
+  'displaysTooltip': [
+    'fixed',
+    'falsePositive',
+    'skipped',
+    'deleted',
+    'alreadyFixed',
+    'tooHard',
+    'answered',
+    'validated',
+    'disabled',
+    'avgTimeSpent'
+  ]
+
+}
+const maprouletteUserStatSchema = {
+  'headers': {
+    'name': { type: 'namelink', accessor: 'name' },
+    'rank': { type: 'number', accessor: 'rank' },
+    'score': { type: 'number', accessor: 'score' }
+  },
+  columnOrder: [
+    'name',
+    'rank',
+    'score'
+  ],
+  'displaysTooltip': [
+    'name',
+    'rank',
+    'score'
+  ]
+
+}
+
+module.exports = {
+  osmesaUserStatSchema,
+  maprouletteUserStatSchema,
+  maprouletteChallengeSchema
+}

--- a/api/src/utils/campaignTableSchema.js
+++ b/api/src/utils/campaignTableSchema.js
@@ -35,15 +35,10 @@ const osmesaUserStatSchema = {
 const maprouletteChallengeSchema = {
   'headers': {
     'fixed': { type: 'number', accessor: 'fixed' },
-    'falsePositive': { type: 'number', accessor: 'falsePositive' },
-    'skipped': { type: 'number', accessor: 'skipped' },
-    'deleted': { type: 'number', accessor: 'deleted' },
     'alreadyFixed': { type: 'number', accessor: 'alreadyFixed' },
+    'falsePositive': { type: 'number', accessor: 'falsePositive' },
     'tooHard': { type: 'number', accessor: 'tooHard' },
-    'answered': { type: 'number', accessor: 'answered' },
-    'validated': { type: 'number', accessor: 'validated' },
-    'disabled': { type: 'number', accessor: 'disabled' },
-    'avgTimeSpent': { type: 'number', accessor: 'avgTimeSpent' }
+    'skipped': { type: 'number', accessor: 'skipped' }
   },
   columnOrder: [
     'fixed',

--- a/api/src/utils/campaignTableSchema.js
+++ b/api/src/utils/campaignTableSchema.js
@@ -44,25 +44,11 @@ const maprouletteChallengeSchema = {
     'fixed',
     'falsePositive',
     'skipped',
-    'deleted',
     'alreadyFixed',
     'tooHard',
-    'answered',
-    'validated',
-    'disabled',
-    'avgTimeSpent'
+    'answered'
   ],
   'displaysTooltip': [
-    'fixed',
-    'falsePositive',
-    'skipped',
-    'deleted',
-    'alreadyFixed',
-    'tooHard',
-    'answered',
-    'validated',
-    'disabled',
-    'avgTimeSpent'
   ]
 
 }

--- a/api/src/utils/sum_editCounts.js
+++ b/api/src/utils/sum_editCounts.js
@@ -4,9 +4,9 @@
  * @param {Object} records
  */
 module.exports = records => {
-  if (!(records && records.users)) return 0
+  if (!(records && records.data)) return 0
 
-  var usersEdits = records.users.reduce(
-    (i, users) => i + parseInt(users.edit_count || 0, 10), 0)
+  var usersEdits = records.data.reduce(
+    (i, data) => i + parseInt(data.edit_count || 0, 10), 0)
   return usersEdits
 }

--- a/components/campaign/CampaignBlurb.js
+++ b/components/campaign/CampaignBlurb.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { formatDecimal, formatKm } from '../../lib/utils/format'
-/*
 export default function Blurb ({
   data,
   km_roads_add,
@@ -16,28 +15,6 @@ export default function Blurb ({
   km_waterways_add,
   km_waterways_mod
 }) {
-
-
-  */
-export default function Blurb (props) {
-  console.log(props)
-
-  const {
-  data,
-  km_roads_add,
-  km_roads_mod,
-  buildings_add,
-  buildings_mod,
-  poi_add,
-  poi_mod,
-  km_railways_add,
-  km_railways_mod,
-  km_coastlines_add,
-  km_coastlines_mod,
-  km_waterways_add,
-  km_waterways_mod
-
-  } = props
   if (data.length === 0) {
     return <h2 className='header--small width--shortened list--block'>
       <p>There are no stats available for this campaign.</p>

--- a/components/campaign/CampaignBlurb.js
+++ b/components/campaign/CampaignBlurb.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { formatDecimal, formatKm } from '../../lib/utils/format'
-
+/*
 export default function Blurb ({
-  users,
+  data,
   km_roads_add,
   km_roads_mod,
   buildings_add,
@@ -16,13 +16,35 @@ export default function Blurb ({
   km_waterways_add,
   km_waterways_mod
 }) {
-  if (users.length === 0) {
+
+
+  */
+export default function Blurb (props) {
+  console.log(props)
+
+  const {
+  data,
+  km_roads_add,
+  km_roads_mod,
+  buildings_add,
+  buildings_mod,
+  poi_add,
+  poi_mod,
+  km_railways_add,
+  km_railways_mod,
+  km_coastlines_add,
+  km_coastlines_mod,
+  km_waterways_add,
+  km_waterways_mod
+
+  } = props
+  if (data.length === 0) {
     return <h2 className='header--small width--shortened list--block'>
       <p>There are no stats available for this campaign.</p>
     </h2>
   }
 
   return <h2 className='header--small width--shortened list--block'>
-    <mark>{users.length}</mark> mappers, mapping <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_railways_add + km_railways_mod)}</mark> of railways, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways.
+    <mark>{data.length}</mark> mappers, mapping <mark>{formatKm(km_roads_add + km_roads_mod)}</mark> of roads, <mark>{formatDecimal(buildings_add + buildings_mod)}</mark> buildings, <mark>{formatDecimal(poi_add + poi_mod)}</mark> Points of Interest, <mark>{formatKm(km_railways_add + km_railways_mod)}</mark> of railways, <mark>{formatKm(km_coastlines_add + km_coastlines_mod)}</mark> of coastlines, and <mark>{formatKm(km_waterways_add + km_waterways_mod)}</mark> of waterways.
   </h2>
 }

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -38,6 +38,45 @@ const osmesaSchema = {
   ]
 
 }
+const mapChallSchema = {
+  'headers': {
+    'fixed': { type: 'number', accessor: 'fixed' },
+    'falsePositive': { type: 'number', accessor: 'falsePositive' },
+    'skipped': { type: 'number', accessor: 'skipped' },
+    'deleted': { type: 'number', accessor: 'deleted' },
+    'alreadyFixed': { type: 'number', accessor: 'alreadyFixed' },
+    'tooHard': { type: 'number', accessor: 'tooHard' },
+    'answered': { type: 'number', accessor: 'answered' },
+    'validated': { type: 'number', accessor: 'validated' },
+    'disabled': { type: 'number', accessor: 'disabled' },
+    'avgTimeSpent': { type: 'number', accessor: 'avgTimeSpent' }
+  },
+  columnOrder: [
+    'fixed',
+    'falsePositive',
+    'skipped',
+    'deleted',
+    'alreadyFixed',
+    'tooHard',
+    'answered',
+    'validated',
+    'disabled',
+    'avgTimeSpent'
+  ],
+  'displaysTooltip': [
+    'fixed',
+    'falsePositive',
+    'skipped',
+    'deleted',
+    'alreadyFixed',
+    'tooHard',
+    'answered',
+    'validated',
+    'disabled',
+    'avgTimeSpent'
+  ]
+
+}
 const mapRouletteSchema = {
   'headers': {
     'name': { type: 'namelink', accessor: 'name' },
@@ -59,7 +98,8 @@ const mapRouletteSchema = {
 
 const tableSchema = {
   osmesa: osmesaSchema,
-  maproulette: mapRouletteSchema
+  maproulette: mapRouletteSchema,
+  'maproulette-challenge': mapChallSchema
 }
 
 export default function CampaignTable (props) {
@@ -68,8 +108,11 @@ export default function CampaignTable (props) {
   }
   let idMap = Object.assign(...props.users.map(({ uid, name }) => ({ [name]: uid })))
 
+  let campaignTopStats
+  let campaignTotals
+
   if (props.type === 'osmesa') {
-    const campaignTopStats = sortBy(prop('edits'), props.users).reverse()
+    campaignTopStats = sortBy(prop('edits'), props.users).reverse()
       .map(user => ({
         ...user,
         km_roads_add_mod: user.km_roads_add + user.km_roads_mod,
@@ -81,7 +124,7 @@ export default function CampaignTable (props) {
       }))
 
     // Construct footer for the campaign table
-    let campaignTotals = {}
+    campaignTotals = {}
 
     let keys = [
       'km_roads_add_mod',
@@ -104,24 +147,15 @@ export default function CampaignTable (props) {
 
     // Add name column
     campaignTotals['name'] = 'Total'
+  }
 
-    return (
-      <div className='widget clearfix table-wrapper'>
-        <Table idMap={idMap} tableSchema={tableSchema.osmesa} data={campaignTopStats} totals={campaignTotals} initialSortColumn='edit_count' />
-        <div>
-          <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
-          <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} />
-        </div>
-      </div>
-    )
-  } else {
-    console.log(props.users)
-    return (<div>
-      <Table idMap={idMap} tableSchema={tableSchema.maproulette} data={props.users} initialSortColumn='rank' />
+  return (
+    <div className='widget clearfix table-wrapper'>
+      <Table idMap={idMap} tableSchema={tableSchema[props.type]} data={campaignTopStats || props.users} totals={campaignTotals || {}} />
       <div>
         <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
+        {campaignTopStats && <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} />}
       </div>
-
-    </div>)
-  }
+    </div>
+  )
 }

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -4,115 +4,17 @@ import CSVExport from '../../components/CSVExport'
 import Table from '../common/Table'
 import { formatDecimal } from '../../lib/utils/format'
 
-const osmesaSchema = {
-  'headers': {
-    'name': { type: 'namelink', accessor: 'name' },
-    'country': { type: 'string', accessor: 'country' },
-    'roads': { type: 'number', accessor: 'km_roads_add_mod' },
-    'buildings': { type: 'number', accessor: 'buildings_add_mod' },
-    'poi': { type: 'number', accessor: 'poi_add_mod' },
-    'railways': { type: 'number', accessor: 'km_railways_add_mod' },
-    'coastlines': { type: 'number', accessor: 'km_coastlines_add_mod' },
-    'waterways': { type: 'number', accessor: 'km_waterways_add_mod' },
-    'changesets': { type: 'number', accessor: 'changeset_count' },
-    'edits': { type: 'number', accessor: 'edit_count' }
-  },
-  'columnOrder': [
-    'name',
-    'country',
-    'roads',
-    'buildings',
-    'poi',
-    'railways',
-    'coastlines',
-    'waterways',
-    'changesets',
-    'edits'
-  ],
-  'displaysTooltip': [
-    'name',
-    'buildings',
-    'poi',
-    'changesets',
-    'edits'
-  ]
-
-}
-const mapChallSchema = {
-  'headers': {
-    'fixed': { type: 'number', accessor: 'fixed' },
-    'falsePositive': { type: 'number', accessor: 'falsePositive' },
-    'skipped': { type: 'number', accessor: 'skipped' },
-    'deleted': { type: 'number', accessor: 'deleted' },
-    'alreadyFixed': { type: 'number', accessor: 'alreadyFixed' },
-    'tooHard': { type: 'number', accessor: 'tooHard' },
-    'answered': { type: 'number', accessor: 'answered' },
-    'validated': { type: 'number', accessor: 'validated' },
-    'disabled': { type: 'number', accessor: 'disabled' },
-    'avgTimeSpent': { type: 'number', accessor: 'avgTimeSpent' }
-  },
-  columnOrder: [
-    'fixed',
-    'falsePositive',
-    'skipped',
-    'deleted',
-    'alreadyFixed',
-    'tooHard',
-    'answered',
-    'validated',
-    'disabled',
-    'avgTimeSpent'
-  ],
-  'displaysTooltip': [
-    'fixed',
-    'falsePositive',
-    'skipped',
-    'deleted',
-    'alreadyFixed',
-    'tooHard',
-    'answered',
-    'validated',
-    'disabled',
-    'avgTimeSpent'
-  ]
-
-}
-const mapRouletteSchema = {
-  'headers': {
-    'name': { type: 'namelink', accessor: 'name' },
-    'rank': { type: 'number', accessor: 'rank' },
-    'score': { type: 'number', accessor: 'score' }
-  },
-  columnOrder: [
-    'name',
-    'rank',
-    'score'
-  ],
-  'displaysTooltip': [
-    'name',
-    'rank',
-    'score'
-  ]
-
-}
-
-const tableSchema = {
-  osmesa: osmesaSchema,
-  maproulette: mapRouletteSchema,
-  'maproulette-challenge': mapChallSchema
-}
-
 export default function CampaignTable (props) {
-  if (props.users.length === 0) {
+  if (props.data.length === 0) {
     return <div />
   }
-  let idMap = Object.assign(...props.users.map(({ uid, name }) => ({ [name]: uid })))
+  let idMap = Object.assign(...props.data.map(({ uid, name }) => ({ [name]: uid })))
 
   let campaignTopStats
   let campaignTotals
 
   if (props.type === 'osmesa') {
-    campaignTopStats = sortBy(prop('edits'), props.users).reverse()
+    campaignTopStats = sortBy(prop('edits'), props.data).reverse()
       .map(user => ({
         ...user,
         km_roads_add_mod: user.km_roads_add + user.km_roads_mod,
@@ -151,7 +53,7 @@ export default function CampaignTable (props) {
 
   return (
     <div className='widget clearfix table-wrapper'>
-      <Table idMap={idMap} tableSchema={tableSchema[props.type]} data={campaignTopStats || props.users} totals={campaignTotals || {}} />
+      <Table idMap={idMap} tableSchema={props.schema} data={campaignTopStats || props.data} totals={campaignTotals || {}} />
       <div>
         <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
         {campaignTopStats && <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} />}

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -53,7 +53,7 @@ export default function CampaignTable (props) {
 
   return (
     <div className='widget clearfix table-wrapper'>
-      <Table idMap={idMap} tableSchema={props.schema} data={campaignTopStats || props.data} totals={campaignTotals || {}} />
+      <Table idMap={idMap} tableSchema={props.schema} notSortable={!props.sortable} data={campaignTopStats || props.data} totals={campaignTotals || {}} />
       <div>
         { campaignTopStats &&
             (<><p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>

--- a/components/campaign/CampaignTable.js
+++ b/components/campaign/CampaignTable.js
@@ -55,8 +55,9 @@ export default function CampaignTable (props) {
     <div className='widget clearfix table-wrapper'>
       <Table idMap={idMap} tableSchema={props.schema} data={campaignTopStats || props.data} totals={campaignTotals || {}} />
       <div>
-        <p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
-        {campaignTopStats && <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} />}
+        { campaignTopStats &&
+            (<><p><em>* All roads, railways, coastlines and waterways represent Km added and modified</em></p>
+              <CSVExport filename={`${props.name}.csv`} data={campaignTopStats} /></>)}
       </div>
     </div>
   )

--- a/components/common/Table.js
+++ b/components/common/Table.js
@@ -133,6 +133,7 @@ export default function Table (props) {
   if (sortable && props.initialSortColumn) {
     useEffect(() => toggleSortBy(props.initialSortColumn, 'descending'), [])
   }
+  console.log(headers)
 
   return (
     <table>
@@ -154,7 +155,7 @@ export default function Table (props) {
                 </th>)
                 : (
                   <th key={column.id} {...column.getHeaderProps()}>
-                    <div className={column.header === 'number' ? 'table-align-right' : ''}>{column.Header}</div>
+                    <a className={column.Cell.name === 'formattedNum' ? 'table-align-right' : ''}>{column.Header}</a>
                   </th>)
             )
           }

--- a/components/common/Table.js
+++ b/components/common/Table.js
@@ -133,7 +133,6 @@ export default function Table (props) {
   if (sortable && props.initialSortColumn) {
     useEffect(() => toggleSortBy(props.initialSortColumn, 'descending'), [])
   }
-  console.log(headers)
 
   return (
     <table>

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -156,7 +156,7 @@
     },
     { 
       "id": "falsePositive",
-      "name": "False Positive"
+      "name": "Not an Issue"
     },
     { 
       "id": "skipped",

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -5,6 +5,12 @@
         "description":"Order of contributors by number of edits"
     },
     {
+        "id":"score",
+        "name":"Score",
+        "description":"Score"
+    },
+
+    {
         "id":"name",
         "name":"Name",
         "description":"Username"

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -149,5 +149,46 @@
         "id":"team-hashtag",
         "name":"Hashtag",
         "description":"Hashtag for this team"
+    },
+    { 
+      "id": "fixed",
+      "name": "Fixed"
+    },
+    { 
+      "id": "falsePositive",
+      "name": "False Positive"
+    },
+    { 
+      "id": "skipped",
+      "name": "Skipped"
+    },
+    { 
+      "id": "deleted",
+      "name":"Deleted"
+    },
+    { 
+      "id": "alreadyFixed",
+      "name": "Already Fixed"
+    },
+    { 
+      "id": "tooHard",
+      "name": "Too Hard"
+    },
+    { 
+      "id": "answered",
+      "name": "Answered"
+    },
+    { 
+      "id": "validated",
+      "name": "Validated"
+    },
+    { 
+      "id": "disabled",
+      "name": "Disabled"
+    },
+    { 
+      "id": "avgTimeSpent",
+      "name":"Average Time Spent"
     }
+
 ]

--- a/lib/i18n/glossary_en.json
+++ b/lib/i18n/glossary_en.json
@@ -189,6 +189,10 @@
     { 
       "id": "avgTimeSpent",
       "name":"Average Time Spent"
+    },
+    { 
+      "id": "completedTasks",
+      "name":"Completed Tasks"
     }
 
 ]

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -160,8 +160,13 @@ export class Campaign extends Component {
                 {
                   (data.success)
                     ? <div>
-                      <Blurb {...data} />
-                      <CampaignTable users={data.users} type={data.statsType} name={meta.name} />
+                      <Blurb {...merge({ users: [], editCounts: 0 }, data)} />
+                      <CampaignTable 
+                      data={data.data} 
+                      type={data.statsType} 
+                      name={meta.name} 
+                      schema={data.schema}
+                      />
                     </div>
                     : <p>There was an error retrieving stats for this campaign.</p>
                 }

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -88,8 +88,9 @@ export class Campaign extends Component {
   }
 
   render () {
-    const { meta, lastUpdate, creationDate, refreshDate, tables } = this.props.campaign
+    const { meta, lastUpdate, creationDate, refreshDate, tables} = this.props.campaign
     const stats = merge({ users: [], editCounts: 0 }, this.props.campaign.stats)
+    const panelContent = this.props.campaign.panelContent || [];
 
     return (
       <div className='Campaigns'>
@@ -130,8 +131,12 @@ export class Campaign extends Component {
         </header>
         <ScoreboardPanel title='' facets={
           [
-            { label: 'Mapped', value: `${parseInt(meta.done, 10)}%` },
-            { label: 'Validated', value: `${parseInt(meta.validated, 10)}%` },
+            //challenge type specific
+            //{ label: 'Mapped', value: `${parseInt(meta.done, 10)}%` },
+            //{ label: 'Validated', value: `${parseInt(meta.validated, 10)}%` },
+            ...panelContent,
+
+            //osmesa specific
             { label: 'Participants', value: stats.users.length },
             { label: 'Total Edits', value: stats.editCounts }
           ]

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -88,8 +88,9 @@ export class Campaign extends Component {
   }
 
   render () {
-    const { meta, lastUpdate, creationDate, refreshDate } = this.props.campaign
+    const { meta, lastUpdate, creationDate, refreshDate, tables } = this.props.campaign
     const stats = merge({ users: [], editCounts: 0 }, this.props.campaign.stats)
+
     return (
       <div className='Campaigns'>
         <header className='header--internal--green header--page'>
@@ -152,16 +153,21 @@ export class Campaign extends Component {
           </div>
         </section>
         <section className='section--tertiary'>
-          <div className='row'>
-            {
-              (stats.success)
-                ? <div>
-                  <Blurb {...stats} />
-                  <CampaignTable users={stats.users} type={stats.statsType} name={meta.name} />
-                </div>
-                : <p>There was an error retrieving stats for this campaign.</p>
-            }
-          </div>
+
+          {
+            tables && tables.map(data => (
+              <div className='row' key={data.statsType}>
+                {
+                  (data.success)
+                    ? <div>
+                      <Blurb {...data} />
+                      <CampaignTable users={data.users} type={data.statsType} name={meta.name} />
+                    </div>
+                    : <p>There was an error retrieving stats for this campaign.</p>
+                }
+              </div>))
+          }
+
         </section>
       </div>
     )

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -130,16 +130,7 @@ export class Campaign extends Component {
           </div>
         </header>
         <ScoreboardPanel title='' facets={
-          [
-            //challenge type specific
-            //{ label: 'Mapped', value: `${parseInt(meta.done, 10)}%` },
-            //{ label: 'Validated', value: `${parseInt(meta.validated, 10)}%` },
-            ...panelContent,
-
-            //osmesa specific
-            { label: 'Participants', value: stats.users.length },
-            { label: 'Total Edits', value: stats.editCounts }
-          ]
+          panelContent
         } />
 
         <section>

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -157,7 +157,7 @@ export class Campaign extends Component {
               (stats.success)
                 ? <div>
                   <Blurb {...stats} />
-                  <CampaignTable users={stats.users} name={meta.name} />
+                  <CampaignTable users={stats.users} type={stats.statsType} name={meta.name} />
                 </div>
                 : <p>There was an error retrieving stats for this campaign.</p>
             }

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -160,12 +160,12 @@ export class Campaign extends Component {
                 {
                   (data.success)
                     ? <div>
-                      <Blurb {...merge({ users: [], editCounts: 0 }, data)} />
-                      <CampaignTable 
-                      data={data.data} 
-                      type={data.statsType} 
-                      name={meta.name} 
-                      schema={data.schema}
+                      {data.statsType === 'osmesa' && <Blurb {...merge({ users: [], editCounts: 0 }, data)} />}
+                      <CampaignTable
+                        data={data.data}
+                        type={data.statsType}
+                        name={meta.name}
+                        schema={data.schema}
                       />
                     </div>
                     : <p>There was an error retrieving stats for this campaign.</p>

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -88,9 +88,8 @@ export class Campaign extends Component {
   }
 
   render () {
-    const { meta, lastUpdate, creationDate, refreshDate, tables} = this.props.campaign
-    const stats = merge({ users: [], editCounts: 0 }, this.props.campaign.stats)
-    const panelContent = this.props.campaign.panelContent || [];
+    const { meta, lastUpdate, creationDate, refreshDate, tables } = this.props.campaign
+    const panelContent = this.props.campaign.panelContent || []
 
     return (
       <div className='Campaigns'>
@@ -129,9 +128,7 @@ export class Campaign extends Component {
             </div>
           </div>
         </header>
-        <ScoreboardPanel title='' facets={
-          panelContent
-        } />
+        <ScoreboardPanel title='' facets={panelContent} />
 
         <section>
           <div className='row widget-container'>
@@ -162,6 +159,7 @@ export class Campaign extends Component {
                         type={data.statsType}
                         name={meta.name}
                         schema={data.schema}
+                        sortable={data.sortable === undefined ? true : data.sortable}
                       />
                     </div>
                     : <p>There was an error retrieving stats for this campaign.</p>

--- a/styles/components/_tables.scss
+++ b/styles/components/_tables.scss
@@ -158,7 +158,15 @@ tr td:not(:first-child).table-align-right {
   text-align: right;
 }
 
+th:not(:first-child) a.table-align-right{
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-end;
+}
+
 th a[class^='sort'].table-align-right,
-span[data-tip].table-align-right:not(first-of-type) {
+span[data-tip].table-align-right:not(:first-of-type) {
   justify-content: flex-end;
 }
+
+


### PR DESCRIPTION
This PR makes attempts at a few things. This is WIP, comments / feedback really needed and appreciated here before I move on.

Some of this has been discussed in slack, will reiterate for clarity.

The goal is to integrate MapRoulette data into scoreboard.
To do this I added a MR class in #589 which loads MR campaigns on `yarn seed`

This PR adds 
- Loading some MapRoulette users on `yarn seed`
     - this may be completely unnecessary? im getting closer, but still rather unclear on what data is expected to be available in the deployed env. But this PR pulls in users from MR just as POC, and then tries to extract statistics from OSMesa (fails most of the time because the users are not there).
- Adds conditional method of getting Campaign data
    - Prior to this, Scoreboard assumes campaign data from all TMs will be accessible in OsMesa (via `osmesa.getCampaign()`) and it is resolved with a `hashtag` and users are found via the same `hashtag`
     - MapRoulette does not seem to be able to be queryable with the same logic
     - So instead this PR adds a TM class function to get project stats from the Map Roulette API (these are different than OSM stats). These stats are somewhat in line with the mockups for this page posted by @LanesGood -> list of users and their generalized levels of contribution for a campaign.
    - I am not particularly happy about some of this approach which takes a `if (map roulette) {} -> else {}` route, once we agree on a general solution


I looked into updated `osm-fabricator` to include MR data, but have held off because the kind of per-statistics / members of the osm schema do not seem to be available from MR. If I have this wrong please lmk!!
