### PR TITLE
Fix wrong http error code when s3 fetch of .mvt fails.

### DIFF
--- a/api/src/routes/extents.js
+++ b/api/src/routes/extents.js
@@ -1,24 +1,42 @@
 const osmesa = require('../services/osmesa')
 
 /**
+ * For error handling the response cannot have the vector tiles response headers
+ *
+ * @param res
+ */
+function revertHeaders (res) {
+  res.set('Content-Type', 'application/json; charset=utf-8')
+  res.set('Content-Encoding', undefined)
+}
+
+/**
  * User Extents route
  * request is of the form `/api/extents/user/test/:z/:x/:y.mvt'
  * it should be rerouted to the s3 path `s3://s3prefix/user/test/:z/:x/:y.mvt`
  */
 async function userExtent (req, res) {
-  const p = req.params
-  res.set('Content-Type', 'application/vnd.mapbox-vector-tile')
-  res.set('Content-Encoding', 'gzip')
-  osmesa.tiles(`user/${p.user}`, p.z, p.x, p.y)
-    .on('error', (err) => {
-      if (err.code === 'NoSuchKey') {
-        res.boom.notFound()
-      } else {
+  try {
+    const p = req.params
+    res.set('Content-Type', 'application/vnd.mapbox-vector-tile')
+    res.set('Content-Encoding', 'gzip')
+    osmesa.tiles(`user/${p.user}`, p.z, p.x, p.y)
+      .on('error', (err) => {
         console.error(err)
-        res.boom.serverError()
-      }
-    })
-    .pipe(res)
+        revertHeaders(res)
+        // the error is from s3, so use it's http status code & message
+        const { message, statusCode } = err
+        res.boom.boomify(err, { message, statusCode })
+      })
+      .pipe(res)
+  } catch (err) {
+    console.error(err)
+    revertHeaders(res)
+    return Promise.resolve(res.boom.boomify(err, {
+      statusCode: 500,
+      message: 'unhandled error in /api/extents/user'
+    }))
+  }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "dotenv-webpack": "^1.5.7",
     "enzyme": "^3.7.0",
     "express": "^4.16.3",
-    "express-boom": "^2.0.0",
+    "express-boom": "^3.0.0",
     "express-promise-router": "^2.0.0",
     "express-session": "^1.15.6",
     "file-loader": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,12 +2837,12 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-boom@3.2.x:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-3.2.2.tgz#0f0cc5d04adc5003b8c7d71f42cca7271fef0e78"
-  integrity sha1-DwzF0ErcUAO4x9cfQsynJx/vDng=
+boom@^7.3.x:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-7.3.0.tgz#733a6d956d33b0b1999da3fe6c12996950d017b9"
+  integrity sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==
   dependencies:
-    hoek "4.x.x"
+    hoek "6.x.x"
 
 boxen@^4.2.0:
   version "4.2.0"
@@ -5739,12 +5739,12 @@ expect@^23.6.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
-express-boom@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/express-boom/-/express-boom-2.0.0.tgz#d400b940e961a8aa2ed8e3f77c595fa1e41b64b3"
-  integrity sha1-1AC5QOlhqKou2OP3fFlfoeQbZLM=
+express-boom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/express-boom/-/express-boom-3.0.0.tgz#d8146f1eea1bf6611f622141c6689ca6defa09f0"
+  integrity sha512-/esN6Am8YE1rzRsi+vBpJkdr8O+GX+oBjRE/hEuBu6Y3uyS9y026XptRZduAMYS8KxyLzXM5Qh+RlnqLOR1pVQ==
   dependencies:
-    boom "3.2.x"
+    boom "^7.3.x"
 
 express-promise-router@^2.0.0:
   version "2.0.0"
@@ -7128,10 +7128,10 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoek@4.x.x:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
-  integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
+hoek@6.x.x:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
+  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
 hoist-non-react-statics@2.5.5, hoist-non-react-statics@^2.3.1:
   version "2.5.5"


### PR DESCRIPTION
- res.boom.serverError() was not a function, so use the s3 statuscode and the boom library to
return a more relevant api response.

- upgrade express-boom to get the boomify() function.

- wrap the osmesa.tiles() call with some additional error handling.

Before review:

- [x] test on staging environment, by changing the s3 credentials temporarily, because in scoreboard local development the s3 client is not even used at all.
