### PR TITLE
Increase timeout to wait for osmesa mock db to finish loading init.sql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,8 @@ services:
   wait-for-db-ready:
     image: dadarek/wait-for-dependencies
     environment:
-      SLEEP_LENGTH: 5
+      SLEEP_LENGTH: 10
+      TIMEOUT_LENGTH: 600
     depends_on:
       - osmesa
       - db


### PR DESCRIPTION
This is a transient error we noticed occasionally in the local dev environment.

Closes #620 