### PR TITLE
Add paging loop for maproulette challenges

### DIFF
--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -62,7 +62,7 @@ class MapRouletteAPI {
       pe: true,
       ce: true,
       order: 'DESC',
-      sort: 'popularity'
+      sort: 'created'
     }
 
     if (this.opts.search_params) {
@@ -72,7 +72,6 @@ class MapRouletteAPI {
     const challenges = []
 
     while (true) {
-      console.log(`requesting map roulette page ${qs.page}`)
       const resp = await rp({
         uri: `${this.api_url}/api/v2/challenges/extendedFind`,
         qs,
@@ -84,7 +83,6 @@ class MapRouletteAPI {
       if (chunk.length < 50 || qs.page > 10) {
         break
       } else {
-        console.log(`got ${chunk.length} challenges`)
       }
     }
 

--- a/api/src/services/tm_types/map_roulette.js
+++ b/api/src/services/tm_types/map_roulette.js
@@ -58,18 +58,36 @@ class MapRouletteAPI {
   async getProjects () {
     let qs = {
       page: 0,
-      limit: 50
+      limit: 50,
+      pe: true,
+      ce: true,
+      order: 'DESC',
+      sort: 'popularity'
     }
+
     if (this.opts.search_params) {
       qs = { ...this.opts.search_params, ...qs }
     }
 
-    const resp = await rp({
-      uri: `${this.api_url}/api/v2/challenges/extendedFind`,
-      qs,
-      headers: { 'Accept-Language': 'en-US,en;q=0.9' }
-    })
-    const challenges = JSON.parse(resp)
+    const challenges = []
+
+    while (true) {
+      console.log(`requesting map roulette page ${qs.page}`)
+      const resp = await rp({
+        uri: `${this.api_url}/api/v2/challenges/extendedFind`,
+        qs,
+        headers: { 'Accept-Language': 'en-US,en;q=0.9' }
+      })
+      const chunk = JSON.parse(resp)
+      challenges.push(...chunk)
+      qs.page = qs.page + 1
+      if (chunk.length < 50 || qs.page > 10) {
+        break
+      } else {
+        console.log(`got ${chunk.length} challenges`)
+      }
+    }
+
     return challenges
   }
 

--- a/api/tests/services/mr.test.js
+++ b/api/tests/services/mr.test.js
@@ -79,11 +79,11 @@ test.serial('Test TM3 schema', async t => {
 test.serial('Test URL forming', async t => {
   const tm = TaskingManagerFactory.createInstance({ id: 1, type: 'mr', url: 'http://maproulette.org', opts: { proxy: 'http://localhost:4848' } })
   let projects = await tm.getProjects() // Should get from the proxy
-  const project = projects.find(p => p.id === 85)
+  const project = projects.find(p => p.id === 14634)
   t.truthy(project)
 
   const url = tm.getUrlForProject(project.id)
-  t.is(url, `http://maproulette.org/challenge/85`)
+  t.is(url, `http://maproulette.org/challenge/14634`)
 })
 
 test.serial('Test extra params', async t => {


### PR DESCRIPTION
Addressing the issue of only pulling in 50 of the oldest maproulette challenges. Unfortunately i don't see a way to determine how many challenges exist through the API, other than requesting until we don't get results. The problem with doing this on seed is that there seem to be roughly 1mil challenges which takes quite a while to download and parse. I don't think it is a good idea to pre-fetch all of these vs maproullette, which requires the user to 'see more' before fetching the next page of results.

As a solution, I have set the scripts to fetch in descending order, sorted by popularity (get most relevant challenges) and increased the cap to 500.
Thoughts?