### PR TITLE
Remove/mr validated

### DIFF
--- a/components/campaigns/CampaignCard.js
+++ b/components/campaigns/CampaignCard.js
@@ -62,10 +62,14 @@ export default ({ campaign }) => {
                 <span className='num--large'>{parseInt(Math.min(100, done), 10)}%</span>
                 <span className='descriptor-chart'>Mapped</span>
               </li>
-              <li className='card--stat'>
-                <span className='num--large'>{parseInt(Math.min(100, validated), 10)}%</span>
-                <span className='descriptor-chart'>Validated</span>
-              </li>
+              {
+                type !== 'mr'
+                  ? <li className='card--stat'>
+                    <span className='num--large'>{parseInt(Math.min(100, validated), 10)}%</span>
+                    <span className='descriptor-chart'>Validated</span>
+                  </li>
+                  : null
+              }
               <li className='card--chip'>
                 <Chip label={type} color={CHIP_COLOR[type]} />
               </li>

--- a/styles/components/_cards.scss
+++ b/styles/components/_cards.scss
@@ -191,6 +191,7 @@
     .card--chip {
       display: grid;
       justify-content: end;
+      grid-column: -2;
     }
   }
   .map {


### PR DESCRIPTION
Removes "Validated" stat from campaign card footer when campaign is from MapRoulette. Closes #630.

<img src="https://user-images.githubusercontent.com/12634024/96953876-33c8b500-14c0-11eb-8895-8fdf6d146433.png" width="550" >
