### PR TITLE
Campaign Table titles + order

### DIFF
--- a/components/charts/LeafletCampaignMap.js
+++ b/components/charts/LeafletCampaignMap.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react'
 import { Map, TileLayer, GeoJSON } from 'react-leaflet'
-import { LoadingState } from '../common/LoadingState'
+import { isNil } from 'ramda'
 import centerOfMass from '@turf/center-of-mass'
 
 class CampaignMap extends Component {
   render () {
-    if (!this.props.feature.id && this.props.feature.type === 'Feature') {
-      return <LoadingState />
+    if (isNil(this.props.feature) || (!this.props.feature.id && this.props.feature.type === 'Feature')) {
+      return <div>Loading...</div>
     }
 
     const center = centerOfMass(this.props.feature)

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -96,6 +96,7 @@ export class Campaign extends Component {
   render () {
     const { meta, lastUpdate, creationDate, refreshDate, tables } = this.props.campaign
     const panelContent = this.props.campaign.panelContent || []
+    const orderedTables = tables && tables.sort((a, b) => { return a.statsType === 'osmesa' ? -1 : b.statsType === 'osmesa' ? 1 : 0 })
 
     return (
       <div className='Campaigns'>
@@ -154,7 +155,7 @@ export class Campaign extends Component {
         <section className='section--tertiary'>
 
           {
-            tables && tables.map(data => (
+            orderedTables && orderedTables.map(data => (
               <div className='row' key={data.statsType}>
                 {
                   (data.success)

--- a/pages/campaign.js
+++ b/pages/campaign.js
@@ -21,8 +21,9 @@ const CampaignMap = dynamic(
 )
 
 const TABLE_TITLES = {
-  'maproulette': 'Challenge Task Progress',
-  'maproulette-challenge': 'Challenge Leaderboard'
+  'osmesa': 'Mapping metrics',
+  'maproulette': 'Challenge Leaderboard',
+  'maproulette-challenge': 'Challenge Task Progress'
 }
 
 export class Campaign extends Component {
@@ -158,9 +159,8 @@ export class Campaign extends Component {
                 {
                   (data.success)
                     ? <div>
-                      {data.statsType === 'osmesa' ? <Blurb {...merge({ users: [], editCounts: 0 }, data)} />
-                        : <h2>{TABLE_TITLES[data.statsType]}</h2>}
-
+                      {data.statsType === 'osmesa' && <Blurb {...merge({ users: [], editCounts: 0 }, data)} />}
+                      <h2>{TABLE_TITLES[data.statsType]}</h2>
                       <CampaignTable
                         data={data.data}
                         type={data.statsType}


### PR DESCRIPTION
This PR:
- Adds osmesa table
- Always includes table title
- Switches MR table names to the appropriate name
- Ensures that Osmesa table is always rendered first on the page, even when MR tables are present

@jvntf I believe this last item is now resolved, but am unable to test on local development given that no MR campaigns have stats in local osmesa campaigns. should we test in the staging environment?