### PR TITLE
Add alphabetical country sort to campaign filters

### DIFF
--- a/api/src/routes/campaigns.js
+++ b/api/src/routes/campaigns.js
@@ -77,6 +77,12 @@ module.exports = async (req, res) => {
       case 'Alphabetical Z-A':
         query = query.orderBy('name', db.raw('desc NULLS LAST'))
         break
+      case 'Countries A-Z':
+        query = query.orderBy('country', db.raw('asc NULLS LAST'))
+        break
+      case 'Countries Z-A':
+        query = query.orderBy('country', db.raw('desc NULLS LAST'))
+        break
     }
     // FIXME: don't hardcode 10 records per page. this makes it impossible to test the various sortTypes above if there are more than 10 campaigns.
     const records = await query.clone().limit(10).offset((parseInt(page) - 1) * 10)

--- a/api/tests/api/campaigns.test.js
+++ b/api/tests/api/campaigns.test.js
@@ -135,6 +135,17 @@ test('Get campaigns sorted alphabetically', async t => {
   t.is(response.body.length, response2.body.length)
 })
 
+test('Sort campaigns by country alphabetically', async (t) => {
+  const response = await request(app)
+    .get('/scoreboard/api/campaigns/?sortType=Countries A-Z')
+    .expect(200)
+  const response2 = await request(app)
+    .get('/scoreboard/api/campaigns?sortType=Countries Z-A')
+    .expect(200)
+  // FIXME: this test should validate the sorted results, but it cannot because of the sql result pagination as implemented in campaigns.js
+  t.is(response.body.length, response2.body.length)
+})
+
 test('Get campaigns with archived', async t => {
   const first = await request(app)
     .get('/scoreboard/api/campaigns?includeArchived=false')

--- a/components/campaigns/CampaignFilters.js
+++ b/components/campaigns/CampaignFilters.js
@@ -83,7 +83,9 @@ export default class Filters extends React.Component {
                 { value: 'Most Recently Updated', label: 'Most Recently Updated' },
                 { value: 'Least Recently Updated', label: 'Least Recently Updated' },
                 { value: 'Alphabetical A-Z', label: 'Alphabetical A-Z' },
-                { value: 'Alphabetical Z-A', label: 'Alphabetical Z-A' }
+                { value: 'Alphabetical Z-A', label: 'Alphabetical Z-A' },
+                { value: 'Country A-Z', label: 'Country A-Z' },
+                { value: 'Country Z-A', label: 'Country Z-A' }
               ]
             }
           />


### PR DESCRIPTION
I started stubbing out an alphabetical "Sort by Country" filter to the campaign filters based on #523. However, I realized that we're not actually getting the country information for a campaign from the tasking manager when ingesting the data.

It does appear that the country information is available per campaign (project) in the new tasking manager v2 API for TM4. Depending on the request URL, this is either returned as the `country` or `countryTag`. I'm unclear whether country is available in the v1 API for TM3 (and TM2?). I do see the country displayed on the project pages of TM3-created projects like this one: https://tasks.hotosm.org/projects/204, and it appears that the v2 API can be used to access those projects: https://hotosm.github.io/swagger/?url=https://tasking-manager-tm4-production-api.hotosm.org/api/v2/system/docs/json/#/projects/get_api_v2_projects__project_id__

I attempted to add the country to the API tasker service in `api/src/services/tm_types/tm3.js`, where I added `obj.country = country` in `updateDB`. This results in an error `error: column "country" of relation "campaigns" does not exist` when attempting to run `yarn seed`. [I'm not pushing this code due to the error]

To add this to the scoreboard database I'm assuming we need to add a migration, and then update the tasker files correctly in the API. Once this is complete, we'll actually be able to add the country to the campaign page, and complete this PR as well as fill in some other past ideas (#440). 

@kamicut or @jvntf would you be able to help get country data associated with the campaigns?