### PR TITLE
Fix to OSM teams API lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+- Fix for new xml2js breaking change
+- Fix for new OSM Teams breaking change where permissions are in separate API calls
 ## [v1.12.0] - 2022-01-04
 ### Added 
 - New user flairs for highlighting tags associated with individual users

--- a/api/src/routes/teams.js
+++ b/api/src/routes/teams.js
@@ -82,6 +82,7 @@ async function get (req, res) {
     const { user: { id: osmId = null } = {} } = req
     const teams = new OSMTeams(osmId)
     const teamData = JSON.parse(await teams.getTeam(teamId))
+    const teamMembers = JSON.parse(await teams.getTeamMembers(teamId))
     const campaigns = await db('campaigns').join(
       db('team_assignments').select(['team_id', 'team_priority', 'campaign_id']).where('team_id', teamId).as('team_assignments'),
       'team_assignments.campaign_id',
@@ -89,7 +90,7 @@ async function get (req, res) {
       'campaigns.id'
     ).join(db('taskers').select('name as tm_name', 'id as taskers_t_id').as('t'),
       'campaigns.tasker_id', '=', 't.taskers_t_id')
-    const teamMemberOsmIds = teamData.members.map(m => m.id)
+    const teamMemberOsmIds = teamMembers.members.map(m => m.id)
     // TODO: use Promise.all() here instead of serial await's
     const users = await db('users').whereIn('osm_id', teamMemberOsmIds)
     const osmesaStats = await OSMesa.getTeamStats(teamMemberOsmIds)
@@ -97,6 +98,7 @@ async function get (req, res) {
     const canEdit = await teams.canEditTeam(teamId)
     const team = {
       ...teamData,
+      ...teamMembers,
       campaigns,
       osmesaStats,
       lastRefreshed,


### PR DESCRIPTION
This fixes the OSM Teams API client library that scoreboard is using because OSM Teams has breaking changes in how permissions work. This closes #676. 

Related: @vgeorge maybe we should release a javascript SDK for OSM Teams that integrations can use?