### PR TITLE
Restrict timeseries chart to top 20 users

### DIFF
--- a/components/charts/TimeSeriesEditsChart.js
+++ b/components/charts/TimeSeriesEditsChart.js
@@ -10,6 +10,8 @@ const chartCrosswalk = {
   'km_coastlines_add_mod': 5
 }
 
+const MAX_USERS_CHART = 20
+
 // builds log scale inclusive of largest statistic
 function getLog10Scale (maxInteger) {
   const linearScale = []
@@ -27,12 +29,14 @@ function getLog10Scale (maxInteger) {
 }
 
 export default function TimeSeriesEditsChart ({ userData }) {
-  const { keys, data } = userData.reduce((chartData, userData) => {
-    chartData.keys[userData.name] = true
-    Object.keys(userData).forEach((k) => {
-      if (userData[k] && chartCrosswalk.hasOwnProperty(k)) {
-        chartData.data[chartCrosswalk[k]][userData.name] =
-          userData[k] + (chartData.data[chartCrosswalk[k]][userData.name] || 0)
+  const topUsers = userData.sort((a, b) => (a.edit_count > b.edit_count ? -1 : 1)).slice(0, MAX_USERS_CHART).reverse()
+
+  const { keys, data } = topUsers.reduce((chartData, topUsers) => {
+    chartData.keys[topUsers.name] = true
+    Object.keys(topUsers).forEach((k) => {
+      if (topUsers[k] && chartCrosswalk.hasOwnProperty(k)) {
+        chartData.data[chartCrosswalk[k]][topUsers.name] =
+        topUsers[k] + (chartData.data[chartCrosswalk[k]][topUsers.name] || 0)
       }
     })
     return chartData
@@ -63,7 +67,7 @@ export default function TimeSeriesEditsChart ({ userData }) {
   const [linearScale, logScale] = getLog10Scale(maxInteger)
 
   return (
-    (userData && userData.length)
+    (topUsers && topUsers.length)
       ? <ResponsiveBar
         width={800}
         data={data}
@@ -71,8 +75,7 @@ export default function TimeSeriesEditsChart ({ userData }) {
         enableLabel={false}
         keys={userKeys}
         indexBy='type'
-        margin={{ top: 50, right: 130, bottom: 50, left: 60 }}
-        padding={0.3}
+        margin={{ top: 50, right: 130, bottom: 50, left: 50 }}
         valueScale={{ type: 'linear' }}
         gridYValues={linearScale}
         axisLeft={{

--- a/components/charts/TimeSeriesEditsChart.js
+++ b/components/charts/TimeSeriesEditsChart.js
@@ -68,36 +68,39 @@ export default function TimeSeriesEditsChart ({ userData }) {
 
   return (
     (topUsers && topUsers.length)
-      ? <ResponsiveBar
-        width={800}
-        data={data}
-        maxValue={linearScale[linearScale.length - 1]}
-        enableLabel={false}
-        keys={userKeys}
-        indexBy='type'
-        margin={{ top: 50, right: 130, bottom: 50, left: 50 }}
-        valueScale={{ type: 'linear' }}
-        gridYValues={linearScale}
-        axisLeft={{
-          tickValues: linearScale,
-          format: (v) => logScale[v]
-        }}
-        tooltip={(d) => {
-          return <div>{`${d.id}: ${d.data[d.id + '_log'].toLocaleString('en-US')} ${d.indexValue}`}</div>
-        }}
-        legends={[
-          {
-            anchor: 'bottom-right',
-            dataFrom: 'keys',
-            direction: 'column',
-            itemHeight: 20,
-            itemWidth: 110,
-            toggleSerie: true,
-            translateX: 120
-          }
-        ]}
-        groupMode='grouped'
-        colors={['#22BDC1', '#8BC544', '#334A42', '#5657C2', '#4FCA9C', '#301F11']}
-      /> : <></>
+      ? <>
+        <h4 className='header--small'>Top {topUsers.length} Users</h4>
+        <ResponsiveBar
+          width={800}
+          data={data}
+          maxValue={linearScale[linearScale.length - 1]}
+          enableLabel={false}
+          keys={userKeys}
+          indexBy='type'
+          margin={{ top: 50, right: 130, bottom: 50, left: 50 }}
+          valueScale={{ type: 'linear' }}
+          gridYValues={linearScale}
+          axisLeft={{
+            tickValues: linearScale,
+            format: (v) => logScale[v]
+          }}
+          tooltip={(d) => {
+            return <div>{`${d.id}: ${d.data[d.id + '_log'].toLocaleString('en-US')} ${d.indexValue}`}</div>
+          }}
+          legends={[
+            {
+              anchor: 'bottom-right',
+              dataFrom: 'keys',
+              direction: 'column',
+              itemHeight: 20,
+              itemWidth: 110,
+              toggleSerie: true,
+              translateX: 120
+            }
+          ]}
+          groupMode='grouped'
+          colors={['#22BDC1', '#8BC544', '#334A42', '#5657C2', '#4FCA9C', '#301F11']}
+        />
+      </> : <></>
   )
 }

--- a/pages/timeseries.js
+++ b/pages/timeseries.js
@@ -480,7 +480,6 @@ export default class TimeSeries extends Component {
               {haveUserData &&
                 <div>
                   <div className='widget chart' style={{ height: '528px', margin: '1rem 0', width: '100%', overflow: 'scroll' }}>
-                    <h4 className='header--small'>Top 20 Users</h4>
                     <TimeSeriesEditsChart userData={Object.values(this.state.accumulatedUserTimeseriesData)} />
                   </div>
                   <div className='page-actions'>

--- a/pages/timeseries.js
+++ b/pages/timeseries.js
@@ -480,6 +480,7 @@ export default class TimeSeries extends Component {
               {haveUserData &&
                 <div>
                   <div className='widget chart' style={{ height: '528px', margin: '1rem 0', width: '100%', overflow: 'scroll' }}>
+                    <h4 className='header--small'>Top 20 Users</h4>
                     <TimeSeriesEditsChart userData={Object.values(this.state.accumulatedUserTimeseriesData)} />
                   </div>
                   <div className='page-actions'>
@@ -492,10 +493,10 @@ export default class TimeSeries extends Component {
           {haveUserData &&
             <div className='row'>
               <div className='widget' style={{ overflow: 'scroll' }}>
+                <h4 className='header--small'>All Users</h4>
                 <Table
                   idMap={this.state.userIdMap}
                   tableSchema={osmesaUserStatSchema}
-                  notSortable
                   data={Object.values(this.state.accumulatedUserTimeseriesData)}
                   totals={{}}
                 />


### PR DESCRIPTION
This PR restricts the Time Series Edits Chart to the top users, sorted by edit, up to 20. The limit of 20 users is somewhat arbitrary, set only by the amount of vertical space available for the legend.

![image](https://user-images.githubusercontent.com/12634024/200064150-5bfc1f04-28ef-4ca6-a172-0f4f2871588a.png)
