### PR TITLE
Make timeseries an admin area page

### DIFF
--- a/components/admin/AdminSectionList.js
+++ b/components/admin/AdminSectionList.js
@@ -48,7 +48,7 @@ export default function AdminSectionList (props) {
         </h3>
         <ul>
           <li>
-            <Link href='/timeseries'>
+            <Link href='/admin/timeseries'>
               <a className='link--normal'>Run Timeseries Analysis</a>
             </Link>
           </li>

--- a/components/admin/AdminSectionList.js
+++ b/components/admin/AdminSectionList.js
@@ -44,6 +44,18 @@ export default function AdminSectionList (props) {
       </li>
       <li className='widget'>
         <h3 className='header--medium'>
+          Timeseries
+        </h3>
+        <ul>
+          <li>
+            <Link href='/timeseries'>
+              <a className='link--normal'>Run Timeseries Analysis</a>
+            </Link>
+          </li>
+        </ul>
+      </li>
+      <li className='widget'>
+        <h3 className='header--medium'>
           Tasking Managers
         </h3>
         <ul>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -179,7 +179,6 @@ class Layout extends React.Component {
                 <li onClick={this.toggle.bind(this)}><NavLink href='/users'>Users</NavLink></li>
                 <li onClick={this.toggle.bind(this)}><NavLink href='/teams'>Teams</NavLink></li>
                 <li onClick={this.toggle.bind(this)}><NavLink href='/countries'>Countries</NavLink></li>
-                {loggedIn && <li onClick={this.toggle.bind(this)}><NavLink href='/timeseries'>Timeseries</NavLink></li>}
                 <li onClick={this.toggle.bind(this)}><NavLink href='/about'>About</NavLink></li>
               </ul>
               {

--- a/pages/admin/timeseries.js
+++ b/pages/admin/timeseries.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 import Select, { Async } from 'react-select'
-import fetch, { createApiUrl } from '../lib/utils/api'
-import Table from '../components/common/Table'
-import TimeSeriesEditsChart from '../components/charts/TimeSeriesEditsChart'
+import Link from '../../components/Link'
+import fetch, { createApiUrl } from '../../lib/utils/api'
+import Table from '../../components/common/Table'
+import TimeSeriesEditsChart from '../../components/charts/TimeSeriesEditsChart'
 import { Duration, DateTime } from 'luxon'
-import CSVExport from '../components/CSVExport'
+import CSVExport from '../../components/CSVExport'
 import debounce from 'lodash.debounce'
 import { AllSubstringsIndexStrategy, Search, UnorderedSearchIndex } from 'js-search'
 
@@ -408,12 +409,19 @@ export default class TimeSeries extends Component {
 
     return (
       <div className='Timeseries'>
-        <header className='header--internal--green header--page'>
+        <header className='header--internal--green header--page header--admin'>
           <div className='row'>
             <div className='section-sub--left section-width-forty'>
-              <ul className='list--two-column' style={{ margin: '0' }}>
-                <li style={{ margin: '0' }}><span>Admin</span></li>
-              </ul>
+              <Link href='/admin'>
+                <a style={{
+                  textTransform: 'uppercase',
+                  fontSize: '0.75rem',
+                  lineHeight: '1rem',
+                  fontFamily: 'Heebo-reg'
+                }}>
+                  Admin
+                </a>
+              </Link>
               <h1 className='header--xlarge'>Timeseries</h1>
             </div>
           </div>

--- a/pages/timeseries.js
+++ b/pages/timeseries.js
@@ -411,6 +411,9 @@ export default class TimeSeries extends Component {
         <header className='header--internal--green header--page'>
           <div className='row'>
             <div className='section-sub--left section-width-forty'>
+              <ul className='list--two-column' style={{ margin: '0' }}>
+                <li style={{ margin: '0' }}><span>Admin</span></li>
+              </ul>
               <h1 className='header--xlarge'>Timeseries</h1>
             </div>
           </div>


### PR DESCRIPTION
This PR:
- Makes `/timeseries` accessible through the Admin panel (please feel free to suggest alternative text - currently "Run Timeseries Analysis")
- Removes link to timeseries from the standard Navbar
- Adds Admin label to timeseries page header

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/12634024/200671012-76390800-8160-449d-a9a1-a860571ee772.png">

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/12634024/200671047-44a915ae-6918-4a5a-b152-2fa9063e7684.png">
